### PR TITLE
Fix version check

### DIFF
--- a/modules/gridfinity_modules.scad
+++ b/modules/gridfinity_modules.scad
@@ -214,7 +214,7 @@ module showClippersForSide(description, gf_num, num_z, lip_style, magnet_diamete
 }
 
 module assert_openscad_version(){
-  assert(version()[0]>2022,"This script requires a newer version of openSCAD. http://openscad.org");
+  assert(version()[0]>=2021,"This script requires a newer version of openSCAD. http://openscad.org");
 }
 // basic block with cutout in top to be stackable, optional holes in bottom
 // start with this and begin 'carving'


### PR DESCRIPTION
Without this fix the version is not checked correctly. The latest version ist 2021.1.

![image](https://github.com/ostat/gridfinity_extended_openscad/assets/556083/0246c985-4ccc-4ea4-a62c-e79c56595b7d)
