### PR TITLE
fixing correct placement of click label in chambers from 2 upward

### DIFF
--- a/modules/module_gridfinity_label.scad
+++ b/modules/module_gridfinity_label.scad
@@ -139,7 +139,7 @@ module gridfinity_label(
             }
           
           if(label_style == "click"){
-             translate([2,labelPoints[i][0]+1,zpoint])
+             translate([2,labelPoints[0][0]+1,zpoint])
              LabelClick();
           } else if(label_relief > 0){
             translate([0,labelPoints[0][0]+max(labelCornerRadius,label_relief+0.5),zpoint-label_relief-fudgeFactor])


### PR DESCRIPTION
I had only seen click label on first chamber, the second and third were moved out, from 4 upwards there was a warning. After some debugging i found a wrong indexing. After fixing that all was fine.

Thx for the awesome work!