### PR TITLE
Enable magnets and screws

### DIFF
--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -77,16 +77,16 @@ box_corner_attachments_only = true;
 floor_thickness = 0.7;
 cavity_floor_radius = -1;// .1
 // Efficient floor option saves material and time, but the internal floor is not flat
-efficient_floor = "on";//[off,on,rounded,smooth] 
+efficient_floor = "off";//[off,on,rounded,smooth]
 // Enable to subdivide bottom pads to allow half-cell offsets
-half_pitch = true;
+half_pitch = false;
 // Removes the internal grid from base the shape
 flat_base = false;
 // Remove floor to create a vertical spacer
 spacer = false;
 
 /* [Label] */
-label_style = "disabled"; //[disabled: no label, normal:normal, gflabel:gflabel basic label, pred:pred - labels by pred, cullenect:Cullenect click labels V2,  cullenect_legacy:Cullenect click labels v1]
+label_style = "normal"; //[disabled: no label, normal:normal, gflabel:gflabel basic label, pred:pred - labels by pred, cullenect:Cullenect click labels V2,  cullenect_legacy:Cullenect click labels v1]
 // Include overhang for labeling (and specify left/right/center justification)
 label_position = "left"; // [left, right, center, leftchamber, rightchamber, centerchamber]
 // Width, Depth, Height, Radius. Width in Gridfinity units of 42mm, Depth and Height in mm, radius in mm. Width of 0 uses full width. Height of 0 uses Depth, height of -1 uses depth*3/4. 
@@ -109,9 +109,9 @@ sliding_lid_lip_enabled = false;
 
 /* [Finger Slide] */
 // Include larger corner fillet
-fingerslide = "rounded"; //[none, rounded, chamfered]
+fingerslide = "none"; //[none, rounded, chamfered]
 // Radius of the corner fillet
-fingerslide_radius = 10;
+fingerslide_radius = 8;
 // wall to enable on, front, back, left, right. 0: disabled; 1: enabled;
 fingerslide_walls=[1,0,0,0];  //[0:1:1]
 

--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -56,7 +56,12 @@ horizontal_irregular_subdivisions = false;
 horizontal_separator_config = "10.5|21|42|50|60";
 
 /* [Base] */
-//size of magnet, diameter and height. Zacks original used 6.5 and 2.4 
+
+// Enable magnets
+enable_magnets = true;
+// Enable screws
+enable_screws = true;
+//size of magnet, diameter and height. Zacks original used 6.5 and 2.4
 magnet_size = [6.5, 2.4];  // .1
 //create relief for magnet removal
 magnet_easy_release = "auto";//["off","auto","inner","outer"] 
@@ -72,16 +77,16 @@ box_corner_attachments_only = true;
 floor_thickness = 0.7;
 cavity_floor_radius = -1;// .1
 // Efficient floor option saves material and time, but the internal floor is not flat
-efficient_floor = "off";//[off,on,rounded,smooth] 
+efficient_floor = "on";//[off,on,rounded,smooth] 
 // Enable to subdivide bottom pads to allow half-cell offsets
-half_pitch = false;
+half_pitch = true;
 // Removes the internal grid from base the shape
 flat_base = false;
 // Remove floor to create a vertical spacer
 spacer = false;
 
 /* [Label] */
-label_style = "normal"; //[disabled: no label, normal:normal, gflabel:gflabel basic label, pred:pred - labels by pred, cullenect:Cullenect click labels V2,  cullenect_legacy:Cullenect click labels v1]
+label_style = "disabled"; //[disabled: no label, normal:normal, gflabel:gflabel basic label, pred:pred - labels by pred, cullenect:Cullenect click labels V2,  cullenect_legacy:Cullenect click labels v1]
 // Include overhang for labeling (and specify left/right/center justification)
 label_position = "left"; // [left, right, center, leftchamber, rightchamber, centerchamber]
 // Width, Depth, Height, Radius. Width in Gridfinity units of 42mm, Depth and Height in mm, radius in mm. Width of 0 uses full width. Height of 0 uses Depth, height of -1 uses depth*3/4. 
@@ -104,9 +109,9 @@ sliding_lid_lip_enabled = false;
 
 /* [Finger Slide] */
 // Include larger corner fillet
-fingerslide = "none"; //[none, rounded, chamfered]
+fingerslide = "rounded"; //[none, rounded, chamfered]
 // Radius of the corner fillet
-fingerslide_radius = 8;
+fingerslide_radius = 10;
 // wall to enable on, front, back, left, right. 0: disabled; 1: enabled;
 fingerslide_walls=[1,0,0,0];  //[0:1:1]
 
@@ -196,10 +201,10 @@ gridfinity_cup(
   fingerslide_radius=fingerslide_radius,
   fingerslide_walls=fingerslide_walls,
   cupBase_settings = CupBaseSettings(
-    magnetSize = magnet_size, 
+    magnetSize = enable_magnets?magnet_size:[0,0],
     magnetEasyRelease = magnet_easy_release, 
     centerMagnetSize = center_magnet_size, 
-    screwSize = screw_size, 
+    screwSize = enable_screws?screw_size:[0,0],
     holeOverhangRemedy = hole_overhang_remedy, 
     cornerAttachmentsOnly = box_corner_attachments_only,
     floorThickness = floor_thickness,

--- a/modules/module_gridfinity_cup.scad
+++ b/modules/module_gridfinity_cup.scad
@@ -319,11 +319,11 @@ module gridfinity_cup(
       if(filled_in == FilledIn_disabled) 
       union(){
         partitioned_cavity(
-          num_x, num_y, num_z, 
+          num_x, num_y, num_z,
           label_settings=label_settings,
           cupBase_settings = cupBase_settings,
-          fingerslide=fingerslide, 
-          fingerslide_radius=fingerslide_radius, 
+          fingerslide=fingerslide,
+          fingerslide_radius=fingerslide_radius,
           fingerslide_walls=fingerslide_walls,
           wall_thickness=wall_thickness,
           chamber_wall_thickness=chamber_wall_thickness,
@@ -338,22 +338,22 @@ module gridfinity_cup(
           horizontal_separator_cut_depth = horizontal_separator_cut_depth,
           vertical_separator_positions = vertical_separator_positions,
           horizontal_separator_positions = horizontal_separator_positions,
-          lip_style=lip_style, 
+          lip_style=lip_style,
           zClearance=zClearance,
           sliding_lid_settings= slidingLidSettings);
       
       color(getColour(color_wallcutout))
         union(){
           floorHeight = calculateFloorHeight(
-              cupBase_settings[iCupBase_MagnetSize][iCylinderDimension_Height], 
-              cupBase_settings[iCupBase_ScrewSize][iCylinderDimension_Height], 
+              cupBase_settings[iCupBase_MagnetSize][iCylinderDimension_Height],
+              cupBase_settings[iCupBase_ScrewSize][iCylinderDimension_Height],
               cupBase_settings[iCupBase_FloorThickness]);
           cavityFloorRadius = calcualteCavityFloorRadius(cupBase_settings[iCupBase_CavityFloorRadius], wall_thickness, cupBase_settings[iCupBase_EfficientFloor]);
           wallTop = calculateWallTop(num_z, lip_style);
           cutoutclearance = gf_cup_corner_radius/2;
 
           tapered_setback = tapered_setback < 0 ? gf_cup_corner_radius : tapered_setback;
-          tapered_corner_size = 
+          tapered_corner_size =
                 tapered_corner_size == -2 ? (wallTop - floorHeight)/2
               : tapered_corner_size < 0 ? wallTop - floorHeight //meant for -1, but also catch others
               : tapered_corner_size == 0 ? wallTop - floorHeight - cavityFloorRadius
@@ -399,14 +399,14 @@ module gridfinity_cup(
             union(){
               if(tapered_corner == "rounded"){
                 roundedCorner(
-                  radius = tapered_corner_size, 
-                  length=(num_x+1)*gf_pitch, 
+                  radius = tapered_corner_size,
+                  length=(num_x+1)*gf_pitch,
                   height = tapered_corner_size);
               }
               else if(tapered_corner == "chamfered"){
                 chamferedCorner(
-                  chamferLength = tapered_corner_size, 
-                  length=(num_x+1)*gf_pitch, 
+                  chamferLength = tapered_corner_size,
+                  length=(num_x+1)*gf_pitch,
                   height = tapered_corner_size);
               }
             }
@@ -584,14 +584,14 @@ module gridfinity_cup(
                   union()
                     if(tapered_corner == "rounded"){
                       roundedCorner(
-                        radius = tapered_corner_size-cutoutclearance, 
-                        length=(num_x+1)*gf_pitch, 
+                        radius = tapered_corner_size-cutoutclearance,
+                        length=(num_x+1)*gf_pitch,
                         height = tapered_corner_size);
                     }
                     else if(tapered_corner == "chamfered"){
                       chamferedCorner(
-                        chamferLength = tapered_corner_size-cutoutclearance, 
-                        length=(num_x+1)*gf_pitch, 
+                        chamferLength = tapered_corner_size-cutoutclearance,
+                        length=(num_x+1)*gf_pitch,
                         height = tapered_corner_size);
                     }
                     
@@ -918,7 +918,7 @@ module partitioned_cavity(num_x, num_y, num_z,
     
   difference() {
     color(getColour(color_cupcavity))
-    basic_cavity(num_x, num_y, num_z, 
+    basic_cavity(num_x, num_y, num_z,
     fingerslide=fingerslide, fingerslide_walls=fingerslide_walls, fingerslide_radius=fingerslide_radius, cupBase_settings=cupBase_settings,
       wall_thickness=wall_thickness,
       lip_style=lip_style, sliding_lid_settings=sliding_lid_settings, zClearance=zClearance);
@@ -928,7 +928,7 @@ module partitioned_cavity(num_x, num_y, num_z,
     
     color(getColour(color_divider))
     tz(sepFloorHeight-fudgeFactor)
-    separators(  
+    separators(
       length=gf_pitch*num_y,
       height=gf_zpitch*(num_z)-sepFloorHeight+fudgeFactor*2-max(zClearance, chamber_wall_zClearance),
       wall_thickness = chamber_wall_thickness,
@@ -943,7 +943,7 @@ module partitioned_cavity(num_x, num_y, num_z,
     
     color(getColour(color_divider))
     translate([gf_pitch*num_x, 0, sepFloorHeight-fudgeFactor])
-    separators(  
+    separators(
       length=gf_pitch*num_x,
       height=gf_zpitch*(num_z)-sepFloorHeight+fudgeFactor*2-max(zClearance, chamber_wall_zClearance),
       wall_thickness = chamber_wall_thickness,
@@ -956,7 +956,7 @@ module partitioned_cavity(num_x, num_y, num_z,
       
     if(label_settings[iLabelSettings_style] != LabelStyle_disabled){
       vertical_separator_positions = calculateSeparators(
-          seperator_config = vertical_separator_positions, 
+          seperator_config = vertical_separator_positions,
           length = gf_pitch*num_y,
           height = gf_zpitch*(num_z)-sepFloorHeight+fudgeFactor*2-max(zClearance, chamber_wall_zClearance),
           wall_thickness = chamber_wall_thickness,
@@ -965,7 +965,7 @@ module partitioned_cavity(num_x, num_y, num_z,
           bend_separation = vertical_separator_bend_separation,
           cut_depth = vertical_separator_cut_depth);
       horizontal_separator_positions = calculateSeparators(
-          seperator_config = horizontal_separator_positions, 
+          seperator_config = horizontal_separator_positions,
           length = gf_pitch*num_x,
           height = gf_zpitch*(num_z)-sepFloorHeight+fudgeFactor*2-max(zClearance, chamber_wall_zClearance),
           wall_thickness = chamber_wall_thickness,
@@ -1147,10 +1147,10 @@ module basic_cavity(num_x, num_y, num_z,
         
         difference(){
           efficient_floor_grid(
-            num_x, num_y, 
+            num_x, num_y,
             floorStyle = cupBase_settings[iCupBase_EfficientFloor],
-            half_pitch=half_pitch, 
-            flat_base=flat_base, 
+            half_pitch=half_pitch,
+            flat_base=flat_base,
             floor_thickness=floor_thickness,
             efficientFloorGridHeight=efficientFloorGridHeight,
             margins=q);
@@ -1161,7 +1161,7 @@ module basic_cavity(num_x, num_y, num_z,
                 EfficientFloorAttachementCaps(
                   grid_copy_corner_index = $gcci,
                   floor_thickness = floor_thickness,
-                  magnet_size = cupBase_settings[iCupBase_MagnetSize], 
+                  magnet_size = cupBase_settings[iCupBase_MagnetSize],
                   screw_size = cupBase_settings[iCupBase_ScrewSize],
                   wall_thickness = magnet_easy_release == MagnetEasyRelease_inner ? wall_thickness*2 : wall_thickness );
           }
@@ -1171,9 +1171,9 @@ module basic_cavity(num_x, num_y, num_z,
     
     //Sliding lid rebate.
     if(sliding_lid_settings[iSlidingLidEnabled])
-        tz(zpoint) 
+        tz(zpoint)
         SlidingLidCavity(
-          num_x = num_x, 
+          num_x = num_x,
           num_y = num_y,
           wall_thickness = wall_thickness,
           sliding_lid_settings = sliding_lid_settings,
@@ -1187,7 +1187,7 @@ module basic_cavity(num_x, num_y, num_z,
     top = num_z*gf_zpitch+gf_Lip_Height;
     height = top-lipBottomZ+fudgeFactor*2;
     
-    hull() 
+    hull()
     for (x=[1.5+0.25+wall_thickness, num_x*gf_pitch-1.5-0.25-wall_thickness]){
       for (y=[11, (num_y)*gf_pitch-seventeen])
       translate([x, y, top-height])
@@ -1198,9 +1198,9 @@ module basic_cavity(num_x, num_y, num_z,
   if (nofloor) {
     tz(-fudgeFactor)
       hull()
-      cornercopy(num_x=num_x, num_y=num_y, r=seventeen) 
+      cornercopy(num_x=num_x, num_y=num_y, r=seventeen)
       cylinder(r=2, h=gf_cupbase_lower_taper_height+fudgeFactor, $fn=32);
-    gridcopy(1, 1) 
+    gridcopy(1, 1)
       EfficientFloor(num_x, num_y,-fudgeFactor, q);
   }
 }


### PR DESCRIPTION
I needed to study the code to understand that, to remove magnet holes, I had to set `magnet_size` and `scew_size` to `[0,0]`.
It might be helpful to add parameters in `baseCup_settings` to make it easier.

I only added 2 variables in `gridfinity_basic_cup.scad` without modifying `baseCup_settings` but perhaps it would be better to do so. it's your choice.

Consider this PR as a quick way to explain an issue.

Bye.