### PR TITLE
Remove warnings due to lacking variables

### DIFF
--- a/modules/module_gridfinity_cup.scad
+++ b/modules/module_gridfinity_cup.scad
@@ -620,8 +620,8 @@ module gridfinity_cup(
                         help=help);
               
               // subtract dividers from outer wall pattern
-              _efficient_floor = cupbase_settings[8];
-              _floor_thickness = cupbase_settings[6];
+              _efficient_floor = cupBase_settings[8];
+              _floor_thickness = cupBase_settings[6];
               sepFloorHeight = (_efficient_floor != EfficientFloor_off ? _floor_thickness : floorHeight);
               translate([0, 0, sepFloorHeight-fudgeFactor])
               separators(

--- a/modules/module_gridfinity_cup.scad
+++ b/modules/module_gridfinity_cup.scad
@@ -619,10 +619,12 @@ module gridfinity_cup(
                         voronoiRadius = wallpattern_voronoi_radius,
                         help=help);
               
-              //subtract dividers from outer wall pattern
-              sepFloorHeight = (efficient_floor != "off" ? floor_thickness : floorHeight);
+              // subtract dividers from outer wall pattern
+              _efficient_floor = cupbase_settings[8];
+              _floor_thickness = cupbase_settings[6];
+              sepFloorHeight = (_efficient_floor != EfficientFloor_off ? _floor_thickness : floorHeight);
               translate([0, 0, sepFloorHeight-fudgeFactor])
-              separators(  
+              separators(
                 length=gf_pitch*num_y,
                 height=gf_zpitch*(num_z)-sepFloorHeight+border*2+fudgeFactor*2,
                 wall_thickness = chamber_wall_thickness+cutoutclearance*2,


### PR DESCRIPTION
OpenSCAD was throwing warnings, I think as a result of having a wall pattern at the same time as using the efficient floor options.

![image](https://github.com/user-attachments/assets/9bc34ad5-6ec4-4c28-829c-9a8cd9f10277)

This seems to fix it, by defining the missing variables `efficient_floor` and `floor_thickness`. Now the warnings are gone!