### PR TITLE
Wallpattern fix to allow patterns on all walls

### DIFF
--- a/modules/module_gridfinity_cup.scad
+++ b/modules/module_gridfinity_cup.scad
@@ -598,8 +598,8 @@ module gridfinity_cup(
               }
             }
             difference(){
-              for(i = [0:1:len(locations)-1])
-                union()
+              union()
+                for(i = [0:1:len(locations)-1])
                   if(wallpattern_walls[i] > 0)
                     //patterns in the outer walls
                     translate(locations[i][1])


### PR DESCRIPTION
Union before loop: As `difference` only deletes from the first child, we have to make that the union of our wall patterns.

Without this, the wall pattern was only being applied to the front wall. Now, it can apply to all walls!

![image](https://github.com/user-attachments/assets/6fa1a705-0211-4f84-b15b-3d4f82219b06)
