### PR TITLE
Item holder bottom setting working!

### DIFF
--- a/gridfinity_item_holder.scad
+++ b/gridfinity_item_holder.scad
@@ -802,9 +802,12 @@ module gridfinity_itemholder(
         sliding_lid_lip_enabled=sliding_lid_lip_enabled);
       /*<!!end gridfinity_basic_cup!!>*/
 
+      itemholder_z_bottom = max(bch, bch+floor_thickness-itemholder_hole_depth);
+      // echo(bch=bch, mfh=mfh, floor_thickness=floor_thickness, itemholder_hole_depth=itemholder_hole_depth, itemholder_z_bottom=itemholder_z_bottom)
+
       color(color_extension)
       translate(cupPosition(position,num_x,num_y))
-      translate([0,0,bch])
+      translate([0, 0, itemholder_z_bottom])
       itemholder(
         num_x=num_x, num_y=num_y, num_z=height,
         knowItemCode = itemholder_known_item,

--- a/gridfinity_item_holder.scad
+++ b/gridfinity_item_holder.scad
@@ -68,7 +68,7 @@ dimensions of the tray cutout, a string with comma separated values, and pipe (|
  - depth, [optional] depth in mm
  - example "0,0,2,1|2,0,2,1,2,5"
 */
-//[[xpos,ypos,xsize,ysize,radius,depth]]. xpos, ypos, the x/y position in gridfinity units.xsize, ysize. the x/y size in gridfinity units. radius, [optional] corner radius in mm.depth, [optional] depth in mm\nexample "0,0,2,1|2,0,2,1,2,5"
+//[[xpos, ypos, xsize, ysize, radius, depth]].  xpos, ypos: the x/y position in gridfinity units.  xsize, ysize: the x/y size in gridfinity units.  radius [optional]: corner radius in mm.  depth [optional]: depth in mm.  Example "0,0,2,1|2,0,2,1,2,5"
 itemholder_customcompartments = "";
 
 
@@ -83,7 +83,7 @@ depth = [1, 0]; //0.5
 // Z dimension excluding. grid units (multiples of 7mm) or mm.
 height = [3, 0]; //0.1
 // Fill in solid block (overrides all following options)
-filled_in = false; 
+filled_in = "disabled"; //[disabled, enabled, enabledfilllip:"Fill cup and lip"]
 // Wall thickness of outer walls. default, height < 8 0.95, height < 16 1.2, height > 16 1.6 (Zack's design is 0.95 mm)
 wall_thickness = 0;  // .01
 // Remove some or all of lip
@@ -91,9 +91,13 @@ lip_style = "normal";  // [ normal, reduced, minimum, none:not stackable ]
 position = "center"; //[default,center,zero]
 //under size the bin top by this amount to allow for better stacking
 zClearance = 0; // 0.1
+//assign colours to the bin, will may 
+set_colour = "enable"; //[disabled, enable, preview, lip]
 
 /* [Subdivisions] */
 chamber_wall_thickness = 1.2;
+//Reduce the wall height by this amount
+chamber_wall_zClearance = 0;//0.1
 // X dimension subdivisions
 vertical_chambers = 1;
 vertical_separator_bend_position = 0;
@@ -115,23 +119,27 @@ horizontal_irregular_subdivisions = false;
 horizontal_separator_config = "10.5|21|42|50|60";
       
 /* [Base] */
-// (Zack's design uses magnet diameter of 6.5)
-magnet_diameter = 0;  // .1
-// Create relief for magnet removal 
-magnet_easy_release = true;
-// (Zack's design uses depth of 6)
-screw_depth = 0;
-center_magnet_diameter =0;
-center_magnet_thickness = 0;
+// Enable magnets
+enable_magnets = true;
+// Enable screws
+enable_screws = true;
+//size of magnet, diameter and height. Zack's original used 6.5 and 2.4
+magnet_size = [6.5, 2.4];  // .1
+//create relief for magnet removal
+magnet_easy_release = "auto";//["off","auto","inner","outer"] 
+//size of screw, diameter and height. Zack's original used 3 and 6
+screw_size = [3, 6]; // .1
+//size of center magnet, diameter and height.
+center_magnet_size = [0,0];
 // Sequential Bridging hole overhang remedy is active only when both screws and magnets are nonzero (and this option is selected)
 hole_overhang_remedy = 2;
-// Only add attachments (magnets and screw) to box corners (prints faster).
+//Only add attachments (magnets and screw) to box corners (prints faster).
 box_corner_attachments_only = true;
 // Minimum thickness above cutouts in base (Zack's design is effectively 1.2)
 floor_thickness = 0.7;
 cavity_floor_radius = -1;// .1
 // Efficient floor option saves material and time, but the internal floor is not flat
-efficient_floor = "off";//[off,on,rounded,smooth] 
+efficient_floor = "off";//[off,on,rounded,smooth]
 // Enable to subdivide bottom pads to allow half-cell offsets
 half_pitch = false;
 // Removes the internal grid from base the shape
@@ -150,11 +158,24 @@ label_relief = [0,0,0,0.6]; // 0.1
 // wall to enable on, front, back, left, right. 0: disabled; 1: enabled;
 label_walls=[0,1,0,0];  //[0:1:1]
 
+/* [Sliding Lid] */
+sliding_lid_enabled = false;
+// 0 = wall thickness *2
+sliding_lid_thickness = 0; //0.1
+// 0 = wall_thickness/2
+sliding_min_wallThickness = 0;//0.1
+// 0 = default_sliding_lid_thickness/2
+sliding_min_support = 0;//0.1
+sliding_clearance = 0.1;//0.1
+sliding_lid_lip_enabled = false;
+
 /* [Finger Slide] */
 // Include larger corner fillet
 fingerslide = "none"; //[none, rounded, chamfered]
 // Radius of the corner fillet
 fingerslide_radius = 8;
+// wall to enable on, front, back, left, right. 0: disabled; 1: enabled;
+fingerslide_walls=[1,0,0,0];  //[0:1:1]
 
 /* [Tapered Corner] */
 tapered_corner = "none"; //[none, rounded, chamfered]
@@ -166,7 +187,7 @@ tapered_setback = -1;//gridfinity_corner_radius/2;
 // Grid wall patter
 wallpattern_enabled=false;
 // Style of the pattern
-wallpattern_style = "grid"; //[grid, hexgrid, voronoi,voronoigrid,voronoihexgrid]
+wallpattern_style = "gridrotated"; //[grid, gridrotated, hexgrid, hexgridrotated, voronoi, voronoigrid, voronoihexgrid]
 // Spacing between pattern
 wallpattern_hole_spacing = 2; //0.1
 // wall to enable on, front, back, left, right.
@@ -176,7 +197,7 @@ wallpattern_dividers_enabled="disabled"; //[disabled, horizontal, vertical, both
 //Number of sides of the hole op
 wallpattern_hole_sides = 6; //[4:square, 6:Hex, 64:circle]
 //Size of the hole
-wallpattern_hole_size = 10; //0.1
+wallpattern_hole_size = 5; //0.1
 // pattern fill mode
 wallpattern_fill = "none"; //[none, space, crop, crophorizontal, cropvertical, crophorizontal_spacevertical, cropvertical_spacehorizontal, spacevertical, spacehorizontal]
 wallpattern_voronoi_noise = 0.75;
@@ -589,11 +610,12 @@ module gridfinity_itemholder(
     labelWalls=label_walls),
   fingerslide=fingerslide,
   fingerslide_radius=fingerslide_radius,
-  magnet_diameter=magnet_diameter,
+  magnet_diameter=magnet_size[0],
+  magnet_depth=magnet_size[1],
   magnet_easy_release=magnet_easy_release,
-  screw_depth=screw_depth,
-  center_magnet_diameter=center_magnet_diameter,
-  center_magnet_thickness=center_magnet_thickness,
+  screw_depth=screw_size[1],
+  center_magnet_diameter=center_magnet_size[0],
+  center_magnet_thickness=center_magnet_size[1],
   floor_thickness=floor_thickness,
   cavity_floor_radius=cavity_floor_radius,
   wall_thickness=wall_thickness,
@@ -678,7 +700,6 @@ module gridfinity_itemholder(
           holeClearance = itemholder_hole_clearance);
 
   _depth = itemCalc[icHoleSize].z;
-  magnet_depth = magnet_diameter > 0 ? gf_magnet_thickness : 0;
   // min floor height
   bch = cupBaseClearanceHeight(magnet_depth, screw_depth);
   mfh = calculateMinFloorHeight(magnet_depth, screw_depth);
@@ -697,78 +718,88 @@ module gridfinity_itemholder(
     difference() {
       /*<!!start gridfinity_basic_cup!!>*/
       gridfinity_cup(
-      width=width, depth=depth, height=height,
-      position=position,
-      filled_in=filled_in,
-      label_settings=label_settings,
-      fingerslide=fingerslide,
-      fingerslide_radius=fingerslide_radius,
-      magnet_diameter=magnet_diameter,
-      magnet_easy_release=magnet_easy_release,
-      screw_depth=screw_depth,
-      center_magnet_diameter=center_magnet_diameter,
-      center_magnet_thickness=center_magnet_thickness,
-      floor_thickness=ft,
-      cavity_floor_radius=cavity_floor_radius,
-      wall_thickness=wall_thickness,
-      hole_overhang_remedy=hole_overhang_remedy,
-      efficient_floor=efficient_floor,
-      chamber_wall_thickness=chamber_wall_thickness,
-      vertical_chambers = vertical_chambers,
-      vertical_separator_bend_position=vertical_separator_bend_position,
-      vertical_separator_bend_angle=vertical_separator_bend_angle,
-      vertical_separator_bend_separation=vertical_separator_bend_separation,
-      vertical_separator_cut_depth=vertical_separator_cut_depth,
-      vertical_irregular_subdivisions=vertical_irregular_subdivisions,
-      vertical_separator_config=vertical_separator_config,
-      horizontal_chambers=horizontal_chambers,
-      horizontal_separator_bend_position=horizontal_separator_bend_position,
-      horizontal_separator_bend_angle=horizontal_separator_bend_angle,
-      horizontal_separator_bend_separation=horizontal_separator_bend_separation,
-      horizontal_separator_cut_depth=horizontal_separator_cut_depth,
-      horizontal_irregular_subdivisions=horizontal_irregular_subdivisions,
-      horizontal_separator_config=horizontal_separator_config, 
-      half_pitch=half_pitch,
-      lip_style=lip_style,
-      zClearance=zClearance,
-      box_corner_attachments_only=box_corner_attachments_only,
-      flat_base = flat_base,
-      spacer=spacer,
-      tapered_corner=tapered_corner,
-      tapered_corner_size = tapered_corner_size,
-      tapered_setback = tapered_setback,
-      wallpattern_enabled=wallpattern_enabled,
-      wallpattern_style=wallpattern_style,
-      wallpattern_walls=wallpattern_walls, 
-      wallpattern_dividers_enabled=wallpattern_dividers_enabled,
-      wallpattern_hole_sides=wallpattern_hole_sides,
-      wallpattern_hole_size=wallpattern_hole_size, 
-      wallpattern_hole_spacing=wallpattern_hole_spacing,
-      wallpattern_fill=wallpattern_fill,
-      wallpattern_voronoi_noise=wallpattern_voronoi_noise,
-      wallpattern_voronoi_radius = wallpattern_voronoi_radius,
-      wallcutout_vertical=wallcutout_vertical,
-      wallcutout_vertical_position=wallcutout_vertical_position,
-      wallcutout_vertical_width=wallcutout_vertical_width,
-      wallcutout_vertical_angle=wallcutout_vertical_angle,
-      wallcutout_vertical_height=wallcutout_vertical_height,
-      wallcutout_vertical_corner_radius=wallcutout_vertical_corner_radius,
-      wallcutout_horizontal=wallcutout_horizontal,
-      wallcutout_horizontal_position=wallcutout_horizontal_position,
-      wallcutout_horizontal_width=wallcutout_horizontal_width,
-      wallcutout_horizontal_angle=wallcutout_horizontal_angle,
-      wallcutout_horizontal_height=wallcutout_horizontal_height,
-      wallcutout_horizontal_corner_radius=wallcutout_horizontal_corner_radius,
-      extendable_Settings=ExtendableSettings(
-        extendablexEnabled = extension_x_enabled, 
-        extendablexPosition = extension_x_position, 
-        extendableyEnabled = extension_y_enabled, 
-        extendableyPosition = extension_y_position, 
-        extendableTabsEnabled = extension_tabs_enabled, 
-        extendableTabSize = extension_tab_size),
-      cutx=cutx,
-      cuty=cuty,
-      help = enable_help);
+        width=width, depth=depth, height=height,
+        position=position,
+        filled_in=filled_in,
+        label_settings=LabelSettings(
+          labelStyle=label_style, 
+          labelPosition=label_position, 
+          labelSize=label_size,
+          labelRelief=label_relief,
+          labelWalls=label_walls),
+        fingerslide=fingerslide,
+        fingerslide_radius=fingerslide_radius,
+        fingerslide_walls=fingerslide_walls,
+        cupBase_settings = CupBaseSettings(
+          magnetSize = enable_magnets?magnet_size:[0,0],
+          magnetEasyRelease = magnet_easy_release, 
+          centerMagnetSize = center_magnet_size, 
+          screwSize = enable_screws?screw_size:[0,0],
+          holeOverhangRemedy = hole_overhang_remedy, 
+          cornerAttachmentsOnly = box_corner_attachments_only,
+          floorThickness = floor_thickness,
+          cavityFloorRadius = cavity_floor_radius,
+          efficientFloor=efficient_floor,
+          halfPitch=half_pitch,
+          flatBase=flat_base,
+          spacer=spacer),
+        wall_thickness=wall_thickness,
+        chamber_wall_thickness=chamber_wall_thickness,
+        chamber_wall_zClearance=chamber_wall_zClearance,
+        vertical_chambers = vertical_chambers,
+        vertical_separator_bend_position=vertical_separator_bend_position,
+        vertical_separator_bend_angle=vertical_separator_bend_angle,
+        vertical_separator_bend_separation=vertical_separator_bend_separation,
+        vertical_separator_cut_depth=vertical_separator_cut_depth,
+        vertical_irregular_subdivisions=vertical_irregular_subdivisions,
+        vertical_separator_config=vertical_separator_config,
+        horizontal_chambers=horizontal_chambers,
+        horizontal_separator_bend_position=horizontal_separator_bend_position,
+        horizontal_separator_bend_angle=horizontal_separator_bend_angle,
+        horizontal_separator_bend_separation=horizontal_separator_bend_separation,
+        horizontal_separator_cut_depth=horizontal_separator_cut_depth,
+        horizontal_irregular_subdivisions=horizontal_irregular_subdivisions,
+        horizontal_separator_config=horizontal_separator_config, 
+        lip_style=lip_style,
+        zClearance=zClearance,
+        tapered_corner=tapered_corner,
+        tapered_corner_size = tapered_corner_size,
+        tapered_setback = tapered_setback,
+        wallpattern_enabled=wallpattern_enabled,
+        wallpattern_style=wallpattern_style,
+        wallpattern_walls=wallpattern_walls, 
+        wallpattern_dividers_enabled=wallpattern_dividers_enabled,
+        wallpattern_hole_sides=wallpattern_hole_sides,
+        wallpattern_hole_size=wallpattern_hole_size, 
+        wallpattern_hole_spacing=wallpattern_hole_spacing,
+        wallpattern_fill=wallpattern_fill,
+        wallpattern_voronoi_noise=wallpattern_voronoi_noise,
+        wallpattern_voronoi_radius = wallpattern_voronoi_radius,
+        wallcutout_vertical=wallcutout_vertical,
+        wallcutout_vertical_position=wallcutout_vertical_position,
+        wallcutout_vertical_width=wallcutout_vertical_width,
+        wallcutout_vertical_angle=wallcutout_vertical_angle,
+        wallcutout_vertical_height=wallcutout_vertical_height,
+        wallcutout_vertical_corner_radius=wallcutout_vertical_corner_radius,
+        wallcutout_horizontal=wallcutout_horizontal,
+        wallcutout_horizontal_position=wallcutout_horizontal_position,
+        wallcutout_horizontal_width=wallcutout_horizontal_width,
+        wallcutout_horizontal_angle=wallcutout_horizontal_angle,
+        wallcutout_horizontal_height=wallcutout_horizontal_height,
+        wallcutout_horizontal_corner_radius=wallcutout_horizontal_corner_radius,
+        extendable_Settings = ExtendableSettings(
+          extendablexEnabled = extension_x_enabled, 
+          extendablexPosition = extension_x_position, 
+          extendableyEnabled = extension_y_enabled, 
+          extendableyPosition = extension_y_position, 
+          extendableTabsEnabled = extension_tabs_enabled, 
+          extendableTabSize = extension_tab_size),
+        sliding_lid_enabled = sliding_lid_enabled, 
+        sliding_lid_thickness = sliding_lid_thickness, 
+        sliding_min_wall_thickness = sliding_min_wallThickness, 
+        sliding_min_support = sliding_min_support, 
+        sliding_clearance = sliding_clearance,
+        sliding_lid_lip_enabled=sliding_lid_lip_enabled);
       /*<!!end gridfinity_basic_cup!!>*/
 
       color(color_extension)


### PR DESCRIPTION
(This builds off of the code changes in #69, you might want to merge that one first.)

This allows setting "itemholder hole depth", and having the holes be "dug" from the top of the floor thickness.

(All below have a floor thickness of 12.2mm and a z height of 3 units, and a square item that is 76.7x76.7mm).

**Before**, the hole would be added just above the floor, resulting in a "lid" (hole depth = 6mm):

![image](https://github.com/user-attachments/assets/e90be935-5cc9-4942-b971-5be98583c1fd)

**Now**, the hole is dug from the top! (same, hole depth = 6mm)

![image](https://github.com/user-attachments/assets/6a0efe76-92aa-4610-8e4e-b6e0964d8fd5)

hole depth = 2mm

![image](https://github.com/user-attachments/assets/70ee69ed-66e6-436c-a384-a6d81eb6d3ae)


hole depth = 25mm (i.e. larger than the floor depth); notice how it doesn't go past where the floor should minimally start.

![image](https://github.com/user-attachments/assets/f3c3cbce-4a00-4eb8-b622-cf123ee68350)


Closes #69 
