### PR TITLE
Add customizable text to bottom of bins

### DIFF
--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -169,6 +169,20 @@ extension_tabs_enabled = true;
 //Tab size, height, width, thickness, style. width default is height, thickness default is 1.4, style {0,1,2}.
 extension_tab_size= [10,0,0,0];
 
+/* [Bottom Text] */
+// Add bin size to bin bottom
+text_1 = true;
+// Size of text, in mm
+text_size = 6; // 0.1
+// Depth of text, in mm
+text_depth = 0.3; // 0.01
+// Font to use
+text_font = "Aldo";  // [Aldo, B612, "Open Sans", Ubuntu]
+// Add free-form text line to bin bottom (printing date, serial, etc)
+text_2 = false;
+// Actual text to add
+text_2_text = "Gridfinity";
+
 /* [debug] */
 render_position = "center"; //[default,center,zero]
 //Slice along the x axis
@@ -271,4 +285,10 @@ gridfinity_cup(
   sliding_min_wall_thickness = sliding_min_wallThickness, 
   sliding_min_support = sliding_min_support, 
   sliding_clearance = sliding_clearance,
-  sliding_lid_lip_enabled=sliding_lid_lip_enabled);
+  sliding_lid_lip_enabled=sliding_lid_lip_enabled,
+  text_1 = text_1,
+  text_2 = text_2,
+  text_2_text = text_2_text,
+  text_size = text_size,
+  text_depth = text_depth
+);

--- a/gridfinity_item_holder.scad
+++ b/gridfinity_item_holder.scad
@@ -210,7 +210,21 @@ extension_y_position = 0.5;
 extension_tabs_enabled = true;
 //Tab size, height, width, thickness, style. width default is height, thickness default is 1.4, style {0,1,2}.
 extension_tab_size= [10,0,0,0];
-    
+
+/* [Bottom Text] */
+// Add bin size to bin bottom
+text_1 = true;
+// Size of text, in mm
+text_size = 6; // 0.1
+// Depth of text, in mm
+text_depth = 0.3; // 0.01
+// Font to use
+text_font = "Aldo";  // [Aldo, B612, "Open Sans", Ubuntu]
+// Add free-form text line to bin bottom (printing date, serial, etc)
+text_2 = false;
+// Actual text to add
+text_2_text = "Gridfinity";
+
 /* [debug] */
 //Slice along the x axis
 cutx = 0; //0.1

--- a/modules/module_gridfinity_cup.scad
+++ b/modules/module_gridfinity_cup.scad
@@ -162,6 +162,20 @@ default_extension_tabs_enabled = true;
 //Tab size, height, width, thickness, style. width default is height, thickness default is 1.4, style {0,1,2}.
 default_extension_tab_size= [10,0,0,0];
 
+/* [Bottom Text] */
+// Add bin size to bin bottom
+text_1 = true;
+// Size of text, in mm
+text_size = 6; // 0.1
+// Depth of text, in mm
+text_depth = 0.3; // 0.01
+// Font to use
+text_font = "Aldo";  // [Aldo, B612, "Open Sans", Ubuntu]
+// Add free-form text line to bin bottom (printing date, serial, etc)
+text_2 = false;
+// Actual text to add
+text_2_text = "Gridfinity";
+
 module end_of_customizer_opts() {}
 /*
 [debug] 
@@ -266,7 +280,13 @@ module gridfinity_cup(
   sliding_lid_thickness = default_sliding_lid_thickness, 
   sliding_min_wall_thickness = default_sliding_min_wallThickness, 
   sliding_min_support = default_sliding_min_support, 
-  sliding_clearance = default_sliding_clearance) {
+  sliding_clearance = default_sliding_clearance,
+  text_1 = text_1,
+  text_2 = text_2,
+  text_2_text = text_2_text,
+  text_size = text_size,
+  text_depth = text_depth
+) {
   
   num_x = calcDimensionWidth(width, true);
   num_y = calcDimensionDepth(depth, true);
@@ -711,6 +731,60 @@ module gridfinity_cup(
           label_settings=label_settings,
           render_option = "socket",
           socket_padding = [0,0,4]);
+
+        // add text to the bottom
+
+        _magnet_position = calculateMagnetPosition(cupBase_settings[iCupBase_MagnetSize][iCylinderDimension_Diameter]);
+        _text_x = wall_thickness + _magnet_position * 1/3;
+        _text_1_y = _magnet_position;
+        
+        if (text_1) {
+          _text_1_text = str(
+            str(num_x),
+            " x ",
+            str(num_y),
+            " x ",
+            str(num_z)
+          );
+
+          color(getColour(color_wallcutout))
+          translate([
+            _text_x,
+            _text_1_y,
+            -1 * text_depth
+          ])
+          linear_extrude(height = text_depth * 2) {
+            rotate(a = [0, 180, 180])
+            text(
+              text = _text_1_text,
+              size = text_size,
+              font = text_font,
+              halign = "left",
+              valign = "top"
+            );
+          }
+        }
+
+        if (text_2) {
+          _text_2_y = _text_1_y + text_size * 1.4;
+
+          color(getColour(color_wallcutout))
+          translate([
+            _text_x,
+            _text_2_y,
+            -1 * text_depth
+          ])
+          linear_extrude(height = text_depth * 2) {
+            rotate(a = [0, 180, 180])
+            text(
+              text = text_2_text,
+              size = text_size,
+              font = text_font,
+              halign = "left",
+              valign = "top"
+            );
+          }
+        }
     }
 
       if(extendable_Settings.x[iExtendableEnabled]!=BinExtensionEnabled_disabled)


### PR DESCRIPTION
First line is the size
Second line is free-form

The text is cut from the bin's base.

![image](https://github.com/user-attachments/assets/d65826c9-aaa3-4a31-9e64-22d036a97813)

I'm still at the beginning of playing with gridfinity bins, and I suppose that the size will become more second natura in time, but it seemed like an obvious thing to include.

For the second line, I intend to use it as a design serial number or a design/print date, so I can find the exact model again if I want to make a copy or edit it later!

Both options are completely optional, and can be turned on or off..

Possible improvements:

- a better font list, or the option to override the font name with a custom font
- move up line 2 if line 1 isn't printed