### PR TITLE
Enable bottom text on item holders

### DIFF
--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -363,4 +363,6 @@ gridfinity_cup(
     baseTextLine2Value = text_2_text,
     baseTextFontSize = text_size,
     baseTextFont = text_font,
-    baseTextDepth = text_depth));
+    baseTextDepth = text_depth
+  )
+);

--- a/gridfinity_item_holder.scad
+++ b/gridfinity_item_holder.scad
@@ -834,7 +834,16 @@ module gridfinity_itemholder(
         sliding_min_wall_thickness = sliding_min_wallThickness, 
         sliding_min_support = sliding_min_support, 
         sliding_clearance = sliding_clearance,
-        sliding_lid_lip_enabled=sliding_lid_lip_enabled);
+        sliding_lid_lip_enabled=sliding_lid_lip_enabled,
+        cupBaseTextSettings = CupBaseTextSettings(
+          baseTextLine1Enabled = text_1,
+          baseTextLine2Enabled = text_2,
+          baseTextLine2Value = text_2_text,
+          baseTextFontSize = text_size,
+          baseTextFont = text_font,
+          baseTextDepth = text_depth
+        )
+      );
       /*<!!end gridfinity_basic_cup!!>*/
 
       itemholder_z_bottom = max(


### PR DESCRIPTION
Seems we were never passing the text settings on when creating items holders, so the text wasn't showing. This fixes that.

I'm not crazy about the text placement (particularly the Y placement, with corner magnets or screws enabled), but that will be a problem to fix on another night.

Thanks again for all you do to keep this up!