### PR TITLE
add captive magnet voids for cups

### DIFF
--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -95,8 +95,8 @@ enable_screws = true;
 magnet_size = [6.5, 2.4];  // .1
 //create relief for magnet removal
 magnet_easy_release = "auto";//["off","auto","inner","outer"] 
-// inner voids for captive magnets
-magnetCaptive = false;
+// raise the magnet void inside the part for print-in-magnets
+magnet_captive_height = 0; // .1
 //size of screw, diameter and height. Zack's original used 3 and 6
 screw_size = [3, 6]; // .1
 //size of center magnet, diameter and height. 
@@ -326,7 +326,7 @@ gridfinity_cup(
   cupBase_settings = CupBaseSettings(
     magnetSize = enable_magnets?magnet_size:[0,0],
     magnetEasyRelease = magnet_easy_release, 
-    magnetCaptive = magnetCaptive,
+    magnetCaptiveHeight = magnet_captive_height,
     centerMagnetSize = center_magnet_size, 
     screwSize = enable_screws?screw_size:[0,0],
     holeOverhangRemedy = hole_overhang_remedy, 

--- a/modules/functions_gridfinity.scad
+++ b/modules/functions_gridfinity.scad
@@ -87,7 +87,7 @@ function cupBaseClearanceHeight(magnet_depth, screw_depth, center_magnet, flat_b
     : max(magnet_depth, screw_depth, gfBaseHeight());
 
 //Height of base including the floor.
-function calculateFloorHeight(magnet_depth, screw_depth, center_magnet=0, floor_thickness, num_z=1, filled_in="disabled", efficient_floor, flat_base) = 
+function calculateFloorHeight(magnet_depth, screw_depth, center_magnet=0, floor_thickness, num_z=1, filled_in="disabled", efficient_floor, flat_base, captive_magnet_height=0) = 
   assert(is_num(magnet_depth))
   assert(is_num(screw_depth))
   assert(is_num(center_magnet))
@@ -96,10 +96,11 @@ function calculateFloorHeight(magnet_depth, screw_depth, center_magnet=0, floor_
   assert(is_string(filled_in))
   assert(is_string(efficient_floor))
   assert(is_string(flat_base))
+  assert(is_num(captive_magnet_height))
   let(
     filled_in = validateFilledIn(filled_in),
     floorThickness = max(floor_thickness, gf_cup_floor_thickness),
-    clearanceHeight = cupBaseClearanceHeight(magnet_depth=magnet_depth, screw_depth=screw_depth, center_magnet=center_magnet, flat_base=flat_base), 
+    clearanceHeight = cupBaseClearanceHeight(magnet_depth=magnet_depth + captive_magnet_height, screw_depth=screw_depth, center_magnet=center_magnet, flat_base=flat_base), 
     result = 
       filled_in != FilledIn_disabled ? num_z * env_pitch().z 
         : efficient_floor != "off" 

--- a/modules/module_gridfinity_block.scad
+++ b/modules/module_gridfinity_block.scad
@@ -66,7 +66,6 @@ module grid_block(
   flat_base=cupBase_settings[iCupBase_FlatBase];
   center_magnet_size = cupBase_settings[iCupBase_CenterMagnetSize];
   magnet_easy_release = cupBase_settings[iCupBase_MagnetEasyRelease];
-  magnetCaptive = cupBase_settings[iCupBase_MagnetCaptive];
   
   outer_size = [env_pitch().x - env_clearance().x, env_pitch().y - env_clearance().y];  // typically 41.5
   block_corner_position = [outer_size.x/2 - gf_cup_corner_radius, outer_size.y/2 - gf_cup_corner_radius];  // need not match center of pad corners
@@ -164,7 +163,6 @@ module grid_block(
           $gcci[2] == [-1,-1] ? -90 :
           $gcci[2] == [ 1,-1] ? 0 : 0;
         rotate([0,0,rdeg-45+(magnet_easy_release==MagnetEasyRelease_outer ? 0 : 180)])
-        echo(cupBase_settings[iCupBase_MagnetCaptive])
         MagnetAndScrewRecess(
           magnetDiameter = magnet_size[iCylinderDimension_Diameter],
           magnetThickness = magnet_size[iCylinderDimension_Height]+0.1,
@@ -173,7 +171,7 @@ module grid_block(
           overhangFixLayers = overhang_fix,
           overhangFixDepth = overhang_fix_depth,
           easyMagnetRelease = magnet_easy_release != MagnetEasyRelease_off,
-          magnetCaptive = magnetCaptive);
+          magnetCaptiveHeight = cupBase_settings[iCupBase_MagnetCaptiveHeight]);
     }
   }
  

--- a/modules/module_gridfinity_cup.scad
+++ b/modules/module_gridfinity_cup.scad
@@ -123,8 +123,8 @@ default_divider_slot_spanning = 0;
 default_magnet_size = [6.5, 2.4];  // .1
 //create relief for magnet removal
 default_magnet_easy_release = "auto";//["off","auto","inner","outer"] 
-// move magnet inside part for print-in magnets
-default_magnet_captive = false;
+// move magnet inside part for print-in magnets 
+default_magnet_captive_height = 0;
 //size of screw, diameter and height. Zack's original used 3 and 6
 default_screw_size = [3, 6]; // .1
 //size of center magnet, diameter and height. 
@@ -254,7 +254,7 @@ module gridfinity_cup(
   cupBase_settings = CupBaseSettings(
     magnetSize = default_magnet_size, 
     magnetEasyRelease = default_magnet_easy_release, 
-    magnetCaptive = default_magnet_captive,
+    magnetCaptiveHeight = default_magnet_captive_height,
     centerMagnetSize = default_center_magnet_size, 
     screwSize = default_screw_size, 
     holeOverhangRemedy = default_hole_overhang_remedy, 
@@ -406,7 +406,8 @@ module gridfinity_cup(
     num_z=num_z,
     filled_in=filled_in, 
     efficient_floor=efficient_floor, 
-    flat_base=cupBase_settings[iCupBase_FlatBase]);
+    flat_base=cupBase_settings[iCupBase_FlatBase],
+    captive_magnet_height=cupBase_settings[iCupBase_MagnetCaptiveHeight]);
   sepFloorHeight = (efficient_floor != "off" ? floor_thickness : floorHeight);
        
   calculated_vertical_separator_positions = calculateSeparators(
@@ -915,7 +916,8 @@ module gridfinity_cup(
         floor_thickness=floor_thickness,
         filled_in="disabled",
         efficient_floor=cupBase_settings[iCupBase_EfficientFloor], 
-        flat_base=cupBase_settings[iCupBase_FlatBase]) + calculateCavityFloorRadius(cupBase_settings[iCupBase_CavityFloorRadius], wall_thickness,efficient_floor)-tabThickness;
+        flat_base=cupBase_settings[iCupBase_FlatBase],
+        captive_magnet_height=cupBase_settings[iCupBase_MagnetCaptiveHeight]) + calculateCavityFloorRadius(cupBase_settings[iCupBase_CavityFloorRadius], wall_thickness,efficient_floor)-tabThickness;
       
       //todo need to correct this
       lipheight = lip_settings[iLipStyle] == "none" ? tabThickness
@@ -1096,7 +1098,8 @@ module partitioned_cavity(num_x, num_y, num_z,
     num_z=num_z,
     filled_in="disabled", 
     efficient_floor=efficient_floor, 
-    flat_base=cupBase_settings[iCupBase_FlatBase]);
+    flat_base=cupBase_settings[iCupBase_FlatBase],
+    captive_magnet_height=cupBase_settings[iCupBase_MagnetCaptiveHeight]);
     
   difference() {
     color(env_colour(color_cupcavity))
@@ -1185,7 +1188,8 @@ module basic_cavity(num_x, num_y, num_z,
       num_z=num_z,
       filled_in=FilledIn_disabled,
       efficient_floor=cupBase_settings[iCupBase_EfficientFloor],
-      flat_base=cupBase_settings[iCupBase_FlatBase]));
+      flat_base=cupBase_settings[iCupBase_FlatBase],
+      captive_magnet_height=cupBase_settings[iCupBase_MagnetCaptiveHeight]));
     
   //Remove floor to create a vertical spacer.
   nofloor = spacer && fingerslide == "none";
@@ -1316,10 +1320,11 @@ module basic_cavity(num_x, num_y, num_z,
            //Screw and magnet covers required for efficient floor
            if(hasCornerAttachments)
              gridcopycorners(num_x, num_y, magnetPosition, box_corner_attachments_only)
+                let(magnet_size=cupBase_settings[iCupBase_MagnetSize])
                 EfficientFloorAttachmentCaps(
                   grid_copy_corner_index = $gcci,
                   floor_thickness = floor_thickness,
-                  magnet_size = cupBase_settings[iCupBase_MagnetSize],
+                  magnet_size = cupBase_settings[iCupBase_MagnetSize] + [0, cupBase_settings[iCupBase_MagnetCaptiveHeight]],
                   screw_size = cupBase_settings[iCupBase_ScrewSize],
                   wall_thickness = magnet_easy_release == MagnetEasyRelease_inner ? wall_thickness*2 : wall_thickness );
           }

--- a/modules/module_gridfinity_cup_base.scad
+++ b/modules/module_gridfinity_cup_base.scad
@@ -41,7 +41,7 @@ iCupBase_Spacer=11;
 iCupBase_MinimumPrintablePadSize=12;
 iCupBase_FlatBaseRoundedRadius=13;
 iCupBase_FlatBaseRoundedEasyPrint=14;
-iCupBase_MagnetCaptive=15;
+iCupBase_MagnetCaptiveHeight=15;
 
 iCylinderDimension_Diameter=0;
 iCylinderDimension_Height=1;
@@ -99,7 +99,7 @@ function CupBaseSettings(
     minimumPrintablePadSize = 0,
     flatBaseRoundedRadius=-1,
     flatBaseRoundedEasyPrint=-1,
-    magnetCaptive = false,
+    magnetCaptiveHeight = 0,
     ) = 
   let(
     magnetSize = 
@@ -131,7 +131,7 @@ function CupBaseSettings(
       minimumPrintablePadSize,
       flatBaseRoundedRadius,
       flatBaseRoundedEasyPrint,
-      magnetCaptive,
+      magnetCaptiveHeight,
       ],
     validatedResult = ValidateCupBaseSettings(result)
   ) validatedResult;
@@ -149,7 +149,7 @@ function ValidateCupBaseSettings(settings, num_x, num_y) =
   assert(is_string(settings[iCupBase_FlatBase]), "CupBase FlatBase Settings must be a string")
   assert(is_bool(settings[iCupBase_Spacer]), "CupBase Spacer Settings must be a boolean")
   assert(is_num(settings[iCupBase_MinimumPrintablePadSize]), "CupBase minimumPrintablePadSize Settings must be a number")
-  assert(is_bool(settings[iCupBase_MagnetCaptive]), "CupBase Magnet Captive setting must be bool")
+  assert(is_num(settings[iCupBase_MagnetCaptiveHeight]), "CupBase Magnet Captive height setting must a number")
   
   let(
     efficientFloor = validateEfficientFloor(settings[iCupBase_EfficientFloor]),
@@ -171,5 +171,5 @@ function ValidateCupBaseSettings(settings, num_x, num_y) =
       settings[iCupBase_MinimumPrintablePadSize],
       settings[iCupBase_FlatBaseRoundedRadius],
       settings[iCupBase_FlatBaseRoundedEasyPrint],
-      settings[iCupBase_MagnetCaptive]
+      settings[iCupBase_MagnetCaptiveHeight]
       ];

--- a/modules/module_utility.scad
+++ b/modules/module_utility.scad
@@ -362,7 +362,7 @@ module SequentialBridgingDoubleHole(
   overhangBridgeCount = 2,
   overhangBridgeThickness = 0.3,
   overhangBridgeCutin = 0.05, //How far should the bridge cut in to the second smaller hole. This helps support the
-  magnetCaptive = false,
+  magnetCaptiveHeight = 0,
   ) 
 {
   fudgeFactor = 0.01;
@@ -377,15 +377,9 @@ module SequentialBridgingDoubleHole(
   union(){
     difference(){
       if (hasOuter) {
-        if (magnetCaptive) {
-          // move the cylinder up into the body (should make a factor of layer height)
-          translate([0,0,0.4])
-          echo("carving voids")
-          cylinder(r=outerHoleRadius, h=outerPlusBridgeHeight);
-        }
-        else {
-          cylinder(r=outerHoleRadius, h=outerPlusBridgeHeight+fudgeFactor);
-        }
+        // move the cylinder up into the body to create internal void
+        translate([0,0,magnetCaptiveHeight])
+        cylinder(r=outerHoleRadius, h=outerPlusBridgeHeight+fudgeFactor);
       }
       
       if (overhangBridgeCount > 0) {
@@ -461,7 +455,7 @@ module MagnetAndScrewRecess(
   overhangFixLayers = 3,
   overhangFixDepth = 0.2,
   easyMagnetRelease = true,
-  magnetCaptive = false){
+  magnetCaptiveHeight = 0){
     fudgeFactor = 0.01;
     
     releaseWidth = 1.3;
@@ -475,7 +469,7 @@ module MagnetAndScrewRecess(
         innerHoleDepth = screwDepth > 0 ? screwDepth+fudgeFactor : 0,
         overhangBridgeCount = overhangFixLayers,
         overhangBridgeThickness = overhangFixDepth,
-        magnetCaptive = magnetCaptive);
+        magnetCaptiveHeight = magnetCaptiveHeight);
       
       if(easyMagnetRelease && magnetDiameter > 0)
       difference(){


### PR DESCRIPTION
kludge in cylindrical voids to the cup tree. config customizer to enable "print-in-magnets" but no other options. the void starts at z=0.4, which is supposed to be two (bottom) layers.

I think it would be a good idea to set a 'lh' global because some features (like the material between the magnet void and the outer surface of the object) are best calibrated to multiples to the layer height.

I did this work originally on commit 8d511b6b. rebasing took a few hours. I'm submitting the PR for cups alone to avoid a repeat.