### PR TITLE
add presets for tray flat_base

### DIFF
--- a/gridfinity_tray.scad
+++ b/gridfinity_tray.scad
@@ -99,7 +99,7 @@ efficient_floor = "off";//[off,on,rounded,smooth]
 // Enable to subdivide bottom pads to allow half-cell offsets
 half_pitch = false;
 // Removes the internal grid from base the shape
-flat_base = "off";
+flat_base = "off";//[off,gridfinity,rounded]
 // Remove floor to create a vertical spacer
 spacer = false;
 


### PR DESCRIPTION
a user complained in #137 that setting flat_base in gridfinity_tray wasn't behaving. i found that the customizer wasn't programmed with the appropiate values (off, gridfinity, rounded) i tested each setting on the default settings. it seems healthy enough