### PR TITLE
added x and y offsets for under text

### DIFF
--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -262,6 +262,10 @@ text_1 = false;
 text_size = 0; // 0.1
 // Depth of text, in mm
 text_depth = 0.3; // 0.01
+// X offset of text 1, in mm
+text_1_x_offset = 0; // 0.1
+// Y offset of text 1, in mm
+text_1_y_offset = 0; // 0.1
 // Font to use
 text_font = "Aldo";  // [Aldo, B612, "Open Sans", Ubuntu]
 // Add free-form text line to bin bottom (printing date, serial, etc)
@@ -451,4 +455,6 @@ gridfinity_cup(
     baseTextLine2Value = text_2_text,
     baseTextFontSize = text_size,
     baseTextFont = text_font,
-    baseTextDepth = text_depth));
+    baseTextDepth = text_depth,
+    baseTextXOffset = text_1_x_offset,
+    baseTextYOffset = text_1_y_offset));

--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -262,10 +262,8 @@ text_1 = false;
 text_size = 0; // 0.1
 // Depth of text, in mm
 text_depth = 0.3; // 0.01
-// X offset of text 1, in mm
-text_1_x_offset = 0; // 0.1
-// Y offset of text 1, in mm
-text_1_y_offset = 0; // 0.1
+// Offset of text , in mm
+text_offset = [0, 0]; // 0.1
 // Font to use
 text_font = "Aldo";  // [Aldo, B612, "Open Sans", Ubuntu]
 // Add free-form text line to bin bottom (printing date, serial, etc)
@@ -456,5 +454,4 @@ gridfinity_cup(
     baseTextFontSize = text_size,
     baseTextFont = text_font,
     baseTextDepth = text_depth,
-    baseTextXOffset = text_1_x_offset,
-    baseTextYOffset = text_1_y_offset));
+    baseTextOffset = text_offset));

--- a/modules/module_gridfinity_cup.scad
+++ b/modules/module_gridfinity_cup.scad
@@ -374,7 +374,9 @@ module gridfinity_cup(
     baseTextLine2Value = default_text_2_text,
     baseTextFontSize = default_text_size,
     baseTextFont = default_text_font,
-    baseTextDepth = default_text_depth)) {
+    baseTextDepth = default_text_depth,
+    baseTextXOffset = text_1_x_offset,
+    baseTextYOffset = text_1_y_offset)) {
   
   //num_x = is_undef($num_x) ? calcDimensionWidth(width, true) : $num_x;
   //num_y = is_undef($num_y) ? calcDimensionDepth(depth, true) : $num_y;

--- a/modules/module_gridfinity_cup.scad
+++ b/modules/module_gridfinity_cup.scad
@@ -375,8 +375,7 @@ module gridfinity_cup(
     baseTextFontSize = default_text_size,
     baseTextFont = default_text_font,
     baseTextDepth = default_text_depth,
-    baseTextXOffset = text_1_x_offset,
-    baseTextYOffset = text_1_y_offset)) {
+    baseTextOffset = text_offset)) {
   
   //num_x = is_undef($num_x) ? calcDimensionWidth(width, true) : $num_x;
   //num_y = is_undef($num_y) ? calcDimensionDepth(depth, true) : $num_y;

--- a/modules/module_gridfinity_cup_base_text.scad
+++ b/modules/module_gridfinity_cup_base_text.scad
@@ -8,8 +8,7 @@ iCupBaseTextLine2Value = 3;
 iCupBaseTextFontSize = 4;
 iCupBaseTextFont = 5;
 iCupBaseTextDepth = 6;
-iCupBaseTextXOffset = 7;
-iCupBaseTextYOffset = 8;
+iCupBaseTextOffset = 7;
 
 function CupBaseTextSettings(
   baseTextLine1Enabled,
@@ -19,8 +18,7 @@ function CupBaseTextSettings(
   baseTextFontSize,
   baseTextFont,
   baseTextDepth,
-  baseTextXOffset,
-  baseTextYOffset) = 
+  baseTextOffset) = 
   [baseTextLine1Enabled, 
   baseTextLine2Enabled,
   baseTextLine1Value,
@@ -28,12 +26,11 @@ function CupBaseTextSettings(
   baseTextFontSize,
   baseTextFont,
   baseTextDepth,
-  baseTextXOffset,
-  baseTextYOffset];
+  baseTextOffset];
 
 module AssertCupBaseTextSettings(settings){
   assert(is_list(settings), "BaseText Settings must be a list")
-  assert(len(settings)==9, "BaseText Settings must length 9");
+  assert(len(settings)==8, "BaseText Settings must length 8");
 } 
 
 // add text to the bottom
@@ -55,8 +52,8 @@ module cup_base_text(
   text_font = cupBaseTextSettings[iCupBaseTextFont];
   text_depth = cupBaseTextSettings[iCupBaseTextDepth];
   
-  text_x_offset = cupBaseTextSettings[iCupBaseTextXOffset];
-  text_y_offset = cupBaseTextSettings[iCupBaseTextYOffset];
+  text_x_offset = cupBaseTextSettings[iCupBaseTextOffset][0];
+  text_y_offset = cupBaseTextSettings[iCupBaseTextOffset][1];
 
   _text_x = wall_thickness + max(base_clearance, magnet_position * 1/3);
   _text_1_y = max(base_clearance, magnet_position * 1/3);

--- a/modules/module_gridfinity_cup_base_text.scad
+++ b/modules/module_gridfinity_cup_base_text.scad
@@ -8,6 +8,8 @@ iCupBaseTextLine2Value = 3;
 iCupBaseTextFontSize = 4;
 iCupBaseTextFont = 5;
 iCupBaseTextDepth = 6;
+iCupBaseTextXOffset = 7;
+iCupBaseTextYOffset = 8;
 
 function CupBaseTextSettings(
   baseTextLine1Enabled,
@@ -16,18 +18,22 @@ function CupBaseTextSettings(
   baseTextLine2Value,
   baseTextFontSize,
   baseTextFont,
-  baseTextDepth) = 
+  baseTextDepth,
+  baseTextXOffset,
+  baseTextYOffset) = 
   [baseTextLine1Enabled, 
   baseTextLine2Enabled,
   baseTextLine1Value,
   baseTextLine2Value,
   baseTextFontSize,
   baseTextFont,
-  baseTextDepth];
+  baseTextDepth,
+  baseTextXOffset,
+  baseTextYOffset];
 
 module AssertCupBaseTextSettings(settings){
   assert(is_list(settings), "BaseText Settings must be a list")
-  assert(len(settings)==7, "BaseText Settings must length 7");
+  assert(len(settings)==9, "BaseText Settings must length 9");
 } 
 
 // add text to the bottom
@@ -49,6 +55,9 @@ module cup_base_text(
   text_font = cupBaseTextSettings[iCupBaseTextFont];
   text_depth = cupBaseTextSettings[iCupBaseTextDepth];
   
+  text_x_offset = cupBaseTextSettings[iCupBaseTextXOffset];
+  text_y_offset = cupBaseTextSettings[iCupBaseTextYOffset];
+
   _text_x = wall_thickness + max(base_clearance, magnet_position * 1/3);
   _text_1_y = max(base_clearance, magnet_position * 1/3);
  
@@ -69,8 +78,8 @@ module cup_base_text(
   if (text_line1_enabled) {
     color(env_colour(color_wallcutout))
     translate([
-      _text_x,
-      _text_1_y,
+      _text_x + text_x_offset,
+      _text_1_y + text_y_offset,
       -1 * text_depth
     ])
     linear_extrude(height = text_depth * 2) {
@@ -94,8 +103,8 @@ module cup_base_text(
 
     color(env_colour(color_wallcutout))
     translate([
-      _text_x,
-      _text_2_y,
+      _text_x + text_x_offset,
+      _text_2_y + text_y_offset,
       -1 * text_depth
     ])
     linear_extrude(height = text_depth * 2) {


### PR DESCRIPTION
this PR just adds the small option to offset the undertext in the basic bin, solves the problem where magnets holes hide the text,
its my first PR and i have absolutely zero experience in openscad, i just read the file and edited what i've though was right. looks like it works
<img width="1628" height="800" alt="2025-09-18-160950_hyprshot" src="https://github.com/user-attachments/assets/fe8fd7c4-1651-4c3b-ade0-7b284cf824c0" />
 