### PR TITLE
Fix label socket Z positioning for pred and gflabel styles

### DIFF
--- a/modules/module_gridfinity_label.scad
+++ b/modules/module_gridfinity_label.scad
@@ -320,7 +320,7 @@ module labelSockets(
         abs(label_num_x)-fullLipWidth*2-binClearance,
         abs(labelPoints[0][0]-labelPoints[1][0])-fullLipWidth,
         (label_relief.z == 0 ? 1 : label_relief.z) + fudgeFactor];
-      translate([-labelCornerRadius+binClearance/2+fullLipWidth,-.3+labelPoints[0][0]+max(labelCornerRadius,label_relief.y+0.5),0-label_relief.z-fudgeFactor])
+      translate([-labelCornerRadius+binClearance/2+fullLipWidth,-.3+labelPoints[0][0]+max(labelCornerRadius,label_relief.y+0.5),fudgeFactor-label_relief.z])
       label_pred_socket(size=predSize);
     } 
     else if(label_style == LabelStyle_gflabel){
@@ -333,7 +333,7 @@ module labelSockets(
               : label_position == LabelPosition_right ? fullLipWidth
               : label_position == LabelPosition_center ? (label_num_x-gflabelSize.x)/2
               : fullLipWidth;
-        translate([gflabelLeftPosition-labelCornerRadius/2,labelPoints[0][0]+0.25,0])
+        translate([gflabelLeftPosition-labelCornerRadius/2,labelPoints[0][0]+0.25,fudgeFactor])
       label_gflabel_socket(
         size=gflabelSize,
         radius=label_relief[3]);


### PR DESCRIPTION
The pred and gflabel label sockets weren't cutting through the shelf surface properly.
fixes #126 