### PR TITLE
Add custom index.html for editor

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,9 @@ jobs:
           config: editor.toml
           output: out
 
+      - name: Use custom index page
+        run: cp index.html out/index.html
+
       - name: Publish
         uses: cloudflare/wrangler-action@v3
         id: cf_publish

--- a/index.html
+++ b/index.html
@@ -1,0 +1,418 @@
+<!doctype html>
+<html lang="en" data-bs-theme="auto">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Gridfinity Extended - Online Customizer</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+    <style>
+        body {
+            padding: 2rem;
+            max-width: 80rem;
+            margin: 0 auto;
+            background-color: var(--page-bg);
+            color: var(--page-fg);
+        }
+
+        :root {
+            color-scheme: light dark;
+            --page-bg: #ffffff;
+            --page-fg: #212529;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --page-bg: #0f1113;
+                --page-fg: #f8f9fa;
+            }
+        }
+
+        .hero-section {
+            margin-bottom: 3rem;
+            padding: 2rem;
+            background: linear-gradient(135deg, rgba(13, 110, 253, 0.1) 0%, rgba(111, 66, 193, 0.1) 100%);
+            border-radius: 0.5rem;
+        }
+
+        .model-card {
+            transition: transform 0.2s, box-shadow 0.2s;
+            height: 100%;
+        }
+
+        .model-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+        }
+
+        .model-card img {
+            height: 200px;
+            object-fit: cover;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+        }
+
+        @media (prefers-color-scheme: dark) {
+            .model-card img {
+                border-bottom-color: rgba(255, 255, 255, 0.125);
+            }
+        }
+
+        .feature-icon {
+            width: 3rem;
+            height: 3rem;
+            margin-bottom: 1rem;
+        }
+
+        .section-header {
+            border-bottom: 2px solid var(--bs-primary);
+            padding-bottom: 0.5rem;
+            margin-bottom: 2rem;
+        }
+    </style>
+    <script>
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+        function setTheme() {
+            document.documentElement.setAttribute("data-bs-theme", prefersDark.matches ? "dark" : "light");
+        }
+        setTheme();
+        prefersDark.addEventListener("change", setTheme);
+    </script>
+</head>
+<body>
+    <!-- Hero Section -->
+    <div class="hero-section">
+        <h1 class="display-4 mb-3">Gridfinity Extended</h1>
+        <p class="lead">An OpenSCAD library for creating customizable Gridfinity storage solutions with extended features and online customization tools.</p>
+        <p class="mb-0">
+            <a href="https://github.com/ostat/gridfinity_extended_openscad" class="btn btn-primary me-2">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-github me-1" viewBox="0 0 16 16">
+                    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+                </svg>
+                GitHub Repository
+            </a>
+            <a href="https://docs.ostat.com/docs/openscad/gridfinity-extended" class="btn btn-outline-primary">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-book me-1" viewBox="0 0 16 16">
+                    <path d="M1 2.828c.885-.37 2.154-.769 3.388-.893 1.33-.134 2.458.063 3.112.752v9.746c-.935-.53-2.12-.603-3.213-.493-1.18.12-2.37.461-3.287.811V2.828zm7.5-.141c.654-.689 1.782-.886 3.112-.752 1.234.124 2.503.523 3.388.893v9.923c-.918-.35-2.107-.692-3.287-.81-1.094-.111-2.278-.039-3.213.492V2.687zM8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783z"/>
+                </svg>
+                Documentation
+            </a>
+        </p>
+    </div>
+
+    <!-- Features Section -->
+    <div class="row mb-5">
+        <div class="col-md-4 text-center mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="feature-icon text-primary" viewBox="0 0 16 16">
+                <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z"/>
+                <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52l-.094-.319z"/>
+            </svg>
+            <h5>Fully Customizable</h5>
+            <p class="text-muted">Adjust dimensions, features, and patterns to create the perfect storage solution for your needs.</p>
+        </div>
+        <div class="col-md-4 text-center mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="feature-icon text-primary" viewBox="0 0 16 16">
+                <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+                <path d="M10.97 4.97a.235.235 0 0 0-.02.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-1.071-1.05z"/>
+            </svg>
+            <h5>Extended Features</h5>
+            <p class="text-muted">Wall patterns, custom cutouts, dividers, tapered corners, and many more advanced options.</p>
+        </div>
+        <div class="col-md-4 text-center mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="feature-icon text-primary" viewBox="0 0 16 16">
+                <path d="M11 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h6zM5 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H5z"/>
+                <path d="M8 14a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
+            </svg>
+            <h5>Online Customizer</h5>
+            <p class="text-muted">No software installation required. Customize and export STL files directly from your browser.</p>
+        </div>
+    </div>
+
+    <!-- About Section -->
+    <div class="mb-5">
+        <h2 class="section-header">About Gridfinity Extended</h2>
+        <p>Gridfinity Extended is an OpenSCAD library originally based on Jamie's library, built with added base features and a customizable extended feature set. It follows the <a href="https://gridfinity.xyz/specification/">Gridfinity specifications</a> while adding powerful customization options.</p>
+        
+        <h4 class="mt-4">Key Features:</h4>
+        <ul>
+            <li><strong>Base Improvements:</strong> Corner-only magnets, flat base options, customizable finger slides, and configurable lip styles</li>
+            <li><strong>Wall Customization:</strong> Patterned walls (grid, hex, voronoi, kumiko), wall cutouts, and tapered corners</li>
+            <li><strong>Advanced Options:</strong> Subdivisions with custom configurations, removable divider walls, and sliding lids</li>
+            <li><strong>Extended Components:</strong> Item holders, dividers, trays, drawers, and custom cutouts</li>
+            <li><strong>Optimization Features:</strong> Efficient floor patterns, light bin options, and split bin support for larger prints</li>
+        </ul>
+    </div>
+
+    <!-- Models Section -->
+    <div class="mb-5">
+        <h2 class="section-header">Available Generators</h2>
+        <p class="text-muted mb-4">Click on any model to open the online customizer. All generators run in your browser and allow you to export STL files for 3D printing.</p>
+        
+        <div class="row g-4">
+            <!-- Basic Cup -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_basic_cup-multi_text.gif" 
+                         class="card-img-top" alt="Gridfinity Basic Cup">
+                    <div class="card-body">
+                        <h5 class="card-title">Basic Cup</h5>
+                        <p class="card-text">The foundation of Gridfinity storage. Fully customizable bins with options for magnets, labels, subdivisions, wall patterns, and finger slides.</p>
+                        <a href="gridfinity_basic_cup" class="btn btn-primary">Customize</a>
+                        <a href="https://docs.ostat.com/docs/openscad/gridfinity-extended/basic-cup/" class="btn btn-outline-secondary btn-sm">Docs</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Baseplate -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_baseplate-baseplate_text.gif" 
+                         class="card-img-top" alt="Gridfinity Baseplate">
+                    <div class="card-body">
+                        <h5 class="card-title">Baseplate</h5>
+                        <p class="card-text">Create custom baseplates to hold your Gridfinity bins. Supports standard, magnet, weighted, and custom grid patterns.</p>
+                        <a href="gridfinity_baseplate" class="btn btn-primary">Customize</a>
+                        <a href="https://docs.ostat.com/docs/openscad/gridfinity-extended/base-plate/" class="btn btn-outline-secondary btn-sm">Docs</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Item Holder -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_item_holder-demo_text.gif" 
+                         class="card-img-top" alt="Gridfinity Item Holder">
+                    <div class="card-body">
+                        <h5 class="card-title">Item Holder</h5>
+                        <p class="card-text">Organize specific items like batteries, memory cards, hex bits, and more. Includes predefined sizes for common items.</p>
+                        <a href="gridfinity_item_holder" class="btn btn-primary">Customize</a>
+                        <a href="https://docs.ostat.com/docs/openscad/gridfinity-extended/item-holder/" class="btn btn-outline-secondary btn-sm">Docs</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Drawers -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_drawers-drawer_text.gif" 
+                         class="card-img-top" alt="Gridfinity Drawers">
+                    <div class="card-body">
+                        <h5 class="card-title">Drawers</h5>
+                        <p class="card-text">Create drawer systems with shelves and sliding compartments. Perfect for organizing small parts and components.</p>
+                        <a href="gridfinity_drawers" class="btn btn-primary">Customize</a>
+                        <a href="https://docs.ostat.com/docs/openscad/gridfinity-extended/drawer/" class="btn btn-outline-secondary btn-sm">Docs</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Lid -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_basic_cup-label_text.gif" 
+                         class="card-img-top" alt="Gridfinity Lid">
+                    <div class="card-body">
+                        <h5 class="card-title">Lid</h5>
+                        <p class="card-text">Protective lids for your Gridfinity bins. Multiple styles available including standard and low-profile options.</p>
+                        <a href="gridfinity_lid" class="btn btn-primary">Customize</a>
+                        <a href="https://docs.ostat.com/docs/openscad/gridfinity-extended/cup-lid/" class="btn btn-outline-secondary btn-sm">Docs</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Sliding Lid -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_basic_cup-multi_text.gif" 
+                         class="card-img-top" alt="Gridfinity Sliding Lid">
+                    <div class="card-body">
+                        <h5 class="card-title">Sliding Lid</h5>
+                        <p class="card-text">Lids that slide into grooves on the bin walls. Provides easy access while keeping contents protected.</p>
+                        <a href="gridfinity_sliding_lid" class="btn btn-primary">Customize</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Tray -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_tray-tray_text.gif" 
+                         class="card-img-top" alt="Gridfinity Tray">
+                    <div class="card-body">
+                        <h5 class="card-title">Tray</h5>
+                        <p class="card-text">Shallow trays for organizing flat items. Customizable compartments and divider configurations.</p>
+                        <a href="gridfinity_tray" class="btn btn-primary">Customize</a>
+                        <a href="https://docs.ostat.com/docs/openscad/gridfinity-extended/tray/" class="btn btn-outline-secondary btn-sm">Docs</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Vertical Divider -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_vertical_divider-divider_text.gif" 
+                         class="card-img-top" alt="Gridfinity Vertical Divider">
+                    <div class="card-body">
+                        <h5 class="card-title">Vertical Divider</h5>
+                        <p class="card-text">Stand-alone vertical dividers for organizing items upright. Adjustable spacing and customizable heights.</p>
+                        <a href="gridfinity_vertical_divider" class="btn btn-primary">Customize</a>
+                        <a href="https://docs.ostat.com/docs/openscad/gridfinity-extended/divider/" class="btn btn-outline-secondary btn-sm">Docs</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Marble -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_basic_cup-multi_text.gif" 
+                         class="card-img-top" alt="Gridfinity Marble Holder">
+                    <div class="card-body">
+                        <h5 class="card-title">Marble Holder</h5>
+                        <p class="card-text">Specialized holder for marbles and small spherical objects. Prevents rolling and keeps items organized.</p>
+                        <a href="gridfinity_marble" class="btn btn-primary">Customize</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Glue Stick -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_item_holder-demo_text.gif" 
+                         class="card-img-top" alt="Gridfinity Glue Stick Holder">
+                    <div class="card-body">
+                        <h5 class="card-title">Glue Stick Holder</h5>
+                        <p class="card-text">Organize glue sticks for 3D printing and crafts. Customizable for different stick sizes and quantities.</p>
+                        <a href="gridfinity_glue_stick" class="btn btn-primary">Customize</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Sieve -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_basic_cup-wallpattern_text.gif" 
+                         class="card-img-top" alt="Gridfinity Sieve">
+                    <div class="card-body">
+                        <h5 class="card-title">Sieve</h5>
+                        <p class="card-text">Perforated bins for sorting and draining. Useful for small parts cleaning and organization.</p>
+                        <a href="gridfinity_sieve" class="btn btn-primary">Customize</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Silverware -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_tray-tray_text.gif" 
+                         class="card-img-top" alt="Gridfinity Silverware Organizer">
+                    <div class="card-body">
+                        <h5 class="card-title">Silverware Organizer</h5>
+                        <p class="card-text">Customizable silverware and utensil organizer. Adjustable compartments for different utensil sizes.</p>
+                        <a href="gridfinity_silverware" class="btn btn-primary">Customize</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Silverware Legacy -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_tray-tray_text.gif" 
+                         class="card-img-top" alt="Gridfinity Silverware Organizer (Legacy)">
+                    <div class="card-body">
+                        <h5 class="card-title">Silverware Organizer (Legacy)</h5>
+                        <p class="card-text">Original version of the silverware organizer. Maintained for compatibility with existing designs.</p>
+                        <a href="gridfinity_silverware_legacy" class="btn btn-primary">Customize</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Socket Holder -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_item_holder-demo_text.gif" 
+                         class="card-img-top" alt="Gridfinity Socket Holder">
+                    <div class="card-body">
+                        <h5 class="card-title">Socket Holder</h5>
+                        <p class="card-text">Organize socket sets and driver bits. Configurable for different socket sizes and drive types.</p>
+                        <a href="gridfinity_socket_holder" class="btn btn-primary">Customize</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Chess -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_item_holder-demo_text.gif" 
+                         class="card-img-top" alt="Gridfinity Chess Set">
+                    <div class="card-body">
+                        <h5 class="card-title">Chess Set</h5>
+                        <p class="card-text">Storage for chess pieces organized by type. Keeps your chess set organized in Gridfinity format.</p>
+                        <a href="gridfinity_chess" class="btn btn-primary">Customize</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Stanley Basic Cup -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_basic_cup-multi_text.gif" 
+                         class="card-img-top" alt="Stanley Basic Cup">
+                    <div class="card-body">
+                        <h5 class="card-title">Stanley Basic Cup</h5>
+                        <p class="card-text">Gridfinity-compatible bins designed for Stanley organizer systems. Bridge the gap between storage systems.</p>
+                        <a href="stanley_basic_cup" class="btn btn-primary">Customize</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Baseplate FLSUN Q5 -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card model-card">
+                    <img src="https://docs.ostat.com/assets/openscad/gridfinity-extended/gridfinity_baseplate-baseplate_text.gif" 
+                         class="card-img-top" alt="Gridfinity Baseplate for FLSUN Q5">
+                    <div class="card-body">
+                        <h5 class="card-title">Baseplate - FLSUN Q5</h5>
+                        <p class="card-text">Custom baseplate optimized for FLSUN Q5 printer bed dimensions. Maximizes usable space.</p>
+                        <a href="gridfinity_baseplate_flsun_q5" class="btn btn-primary">Customize</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Resources Section -->
+    <div class="mb-5">
+        <h2 class="section-header">Resources</h2>
+        <div class="row">
+            <div class="col-md-6">
+                <h5>Documentation</h5>
+                <ul>
+                    <li><a href="https://docs.ostat.com/docs/openscad/gridfinity-extended">Complete Documentation</a></li>
+                    <li><a href="https://github.com/ostat/gridfinity_extended_openscad">GitHub Repository</a></li>
+                    <li><a href="https://gridfinity.xyz/specification/">Gridfinity Specifications</a></li>
+                    <li><a href="https://makerworld.com/en/models/481168">MakerWorld Customizer</a></li>
+                </ul>
+            </div>
+            <div class="col-md-6">
+                <h5>Community</h5>
+                <ul>
+                    <li><a href="https://github.com/ostat/gridfinity_extended_openscad/issues">Report Issues</a></li>
+                    <li><a href="https://github.com/ostat/gridfinity_extended_openscad/discussions">Discussions</a></li>
+                    <li><a href="https://gridfinity.xyz/">Official Gridfinity Site</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="text-center text-muted py-4 border-top">
+        <p class="mb-0">
+            Gridfinity Extended by <a href="https://github.com/ostat">ostat</a> | 
+            Based on <a href="https://github.com/vector76/gridfinity_openscad">Jamie's library</a> | 
+            Online editor powered by <a href="https://github.com/yawkat/web-openscad-editor">web-openscad-editor</a>
+        </p>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
+            crossorigin="anonymous"></script>
+</body>
+</html>


### PR DESCRIPTION
In lieu of https://github.com/yawkat/web-openscad-editor/issues/6 , here's an example of a custom index.html. I generated it in ten minutes using an LLM. It has some broken images, but other than that I think it looks much better than anything I could generate in web-openscad-editor. Keeping the index.html in this project gives you full control over the layout and contents, instead of conforming to a set schema.

@ostat PTAL