### PR TITLE
Added efficient floor limit

### DIFF
--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -100,6 +100,8 @@ floor_thickness = 0.7;
 cavity_floor_radius = -1;// .1
 // Efficient floor option saves material and time, but the internal floor is not flat
 efficient_floor = "off";//[off,on,rounded,smooth]
+// Limit of the efficient floor. -1 will disable the limit, -2 limit to be floor thickness + magnet depth.
+efficient_floor_limit = -1; // 0.1
 // AKA half pitch. Enable to subdivide bottom pads to allow sub-cell offsets
 sub_pitch = 1; //[1:"disabled",2:"half pitch",3:"third pitch",4:"quarter pitch"]
 // Removes the internal grid from base the shape
@@ -356,7 +358,8 @@ gridfinity_cup(
     minimumPrintablePadSize=minimum_printable_pad_size,
     flatBaseRoundedRadius = flat_base_rounded_radius,
     flatBaseRoundedEasyPrint = flat_base_rounded_easyPrint,
-    alignGrid = [align_grid_x, align_grid_y]
+    alignGrid = [align_grid_x, align_grid_y],
+    efficientFloorLimit = efficient_floor_limit
     ),
   wall_thickness=wall_thickness,
   vertical_chambers = ChamberSettings(

--- a/modules/module_gridfinity_cup.scad
+++ b/modules/module_gridfinity_cup.scad
@@ -118,6 +118,7 @@ default_cavity_floor_radius = -1;
 default_hole_overhang_remedy = 2;
 // Save material with thinner floor
 default_efficient_floor = "off";//["off","on","rounded","smooth"] 
+default_efficient_floor_limit = -1;
 // Remove floor to create a spacer
 default_spacer = false;
 // Half-pitch base pads for offset stacking
@@ -254,6 +255,7 @@ module gridfinity_cup(
     floorThickness = default_floor_thickness,
     cavityFloorRadius = default_cavity_floor_radius,
     efficientFloor=default_efficient_floor,
+    efficientFloorLimit = default_efficient_floor_limit,
     subPitch=default_sub_pitch,
     flatBase=default_flat_base,
     spacer=default_spacer),
@@ -1378,11 +1380,12 @@ module basic_cavity(num_x, num_y, num_z,
         cupBase_settings[iCupBase_ScrewSize][iCylinderDimension_Height]);
       hasCornerAttachments = magnet_diameter > 0 || screw_depth > 0;
       efficientFloorGridHeight = max(magnetCoverHeight,gfBaseHeight())+floor_thickness;
+      efficient_floor_limit = cupBase_settings[iCupBase_EfficientFloorLimit];
       if(env_help_enabled("trace")) echo("basic_cavity", efficient_floor=cupBase_settings[iCupBase_EfficientFloor], efficientFloorGridHeight=efficientFloorGridHeight,  floor_thickness=floor_thickness);
       difference(){
         tz(-fudgeFactor)
           cube([num_x*env_pitch().x, num_y*env_pitch().y, efficientFloorGridHeight]);
-        
+
         difference(){
           efficient_floor_grid(
             num_x, num_y,
@@ -1393,10 +1396,11 @@ module basic_cavity(num_x, num_y, num_z,
             efficientFloorGridHeight=efficientFloorGridHeight,
             align_grid = cupBase_settings[iCupBase_AlignGrid],
             margins=q);
-           
-           //Screw and magnet covers required for efficient floor
-           if(hasCornerAttachments)
-             gridcopycorners(num_x, num_y, magnetPosition, box_corner_attachments_only)
+
+          //Screw magnet covers and Limit required for efficient floor
+          union(){
+            if(hasCornerAttachments)
+              gridcopycorners(num_x, num_y, magnetPosition, box_corner_attachments_only)
                 let(magnet_size=cupBase_settings[iCupBase_MagnetSize])
                 EfficientFloorAttachmentCaps(
                   grid_copy_corner_index = $gcci,
@@ -1407,9 +1411,18 @@ module basic_cavity(num_x, num_y, num_z,
                   //if magnet is captive, 
                   wall_thickness = 
                     ((cupBase_settings[iCupBase_NormalisedMagnetEasyRelease] == MagnetEasyRelease_inner && cupBase_settings[iCupBase_MagnetCaptiveHeight] == 0)
-                    || (cupBase_settings[iCupBase_MagnetEasyRelease] != MagnetEasyRelease_off && cupBase_settings[iCupBase_MagnetSideAccess]))
-                      ? wall_thickness*2
-                      : wall_thickness );
+                     || (cupBase_settings[iCupBase_MagnetEasyRelease] != MagnetEasyRelease_off && cupBase_settings[iCupBase_MagnetSideAccess]))
+                    ? wall_thickness*2
+                    : wall_thickness );
+
+              if(efficient_floor_limit != -1)
+                {
+                    efficient_floor_limit_height = efficient_floor_limit == -2 ? magnetCoverHeight + floor_thickness + 0.01 : efficient_floor_limit;
+                    cube([num_x*env_pitch().x,num_y*env_pitch().y, efficient_floor_limit_height]);
+
+
+                }
+           }
           }
         }
       }

--- a/modules/module_gridfinity_cup_base.scad
+++ b/modules/module_gridfinity_cup_base.scad
@@ -48,6 +48,7 @@ iCupBase_AlignGrid=17;
 iCupBase_MagnetSideAccess=18;
 iCupBase_MagnetCrushDepth=19;
 iCupBase_MagnetChamfer=20;
+iCupBase_EfficientFloorLimit=21;
 
 iCylinderDimension_Diameter=0;
 iCylinderDimension_Height=1;
@@ -108,7 +109,8 @@ function CupBaseSettings(
     magnetCrushDepth = 0,
     magnetChamfer = 0,
     alignGrid = ["near", "near"],
-    magnetSideAccess = false
+    magnetSideAccess = false,
+    efficientFloorLimit = -1
     ) = 
   let(
     magnetSize = 
@@ -147,13 +149,14 @@ function CupBaseSettings(
       alignGrid,
       magnetSideAccess,
       magnetCrushDepth,
-      magnetChamfer
+      magnetChamfer,
+      efficientFloorLimit
       ],
     validatedResult = ValidateCupBaseSettings(result)
   ) validatedResult;
   
 function ValidateCupBaseSettings(settings, num_x, num_y) =
-  assert(is_list(settings) && len(settings) == 21, typeerror_list("CupBase Settings", settings, 19))
+  assert(is_list(settings) && len(settings) == 22, typeerror_list("CupBase Settings", settings, 19))
   assert(is_list(settings[iCupBase_MagnetSize]) && len(settings[iCupBase_MagnetSize])==2, "CupBase Magnet Setting must be a list of length 2")
   assert(is_list(settings[iCupBase_CenterMagnetSize]) && len(settings[iCupBase_CenterMagnetSize])==2, "CenterMagnet Magnet Setting must be a list of length 2")
   assert(is_list(settings[iCupBase_ScrewSize]) && len(settings[iCupBase_ScrewSize])==2, "ScrewSize Magnet Setting must be a list of length 2")
@@ -168,6 +171,7 @@ function ValidateCupBaseSettings(settings, num_x, num_y) =
   assert(is_num(settings[iCupBase_MagnetCaptiveHeight]), "CupBase Magnet Captive height setting must a number")
   assert(is_list(settings[iCupBase_AlignGrid]) && len(settings[iCupBase_AlignGrid])==2, "CupBase AlignGrid Setting must be a list of length 2")
   assert(is_bool(settings[iCupBase_MagnetSideAccess]), "CupBase MagnetSideAccess Settings must be a boolean")
+  assert(is_num(settings[iCupBase_EfficientFloorLimit]), "CupBase EfficientFloorLimit Settings must be a number")
   [
       settings[iCupBase_MagnetSize],
       validateMagnetEasyRelease(settings[iCupBase_MagnetEasyRelease]),
@@ -189,5 +193,6 @@ function ValidateCupBaseSettings(settings, num_x, num_y) =
       settings[iCupBase_AlignGrid],
       settings[iCupBase_MagnetSideAccess],
       settings[iCupBase_MagnetCrushDepth],
-      settings[iCupBase_MagnetChamfer]
+      settings[iCupBase_MagnetChamfer],
+      settings[iCupBase_EfficientFloorLimit]
       ];


### PR DESCRIPTION
I've added a simple limit to the efficent floor
the first image is the baisc floor, but sometimes its too thick
the second image is the regular efficent base which is too thin, and may cause problems with text cutout and the magnets holes are in the way

so i've added the parameter to limit it, -1 will disable the limit, and -2 will set it to be just above the magnet holes. as you can see in the 4th image

<img width="1310" height="539" alt="image" src="https://github.com/user-attachments/assets/2e30f879-ca1d-4500-88a4-617fa3c1e79b" />
<img width="1307" height="598" alt="image" src="https://github.com/user-attachments/assets/adca92da-a1b1-40b5-a13f-44c0d8415b6d" />

<img width="1283" height="576" alt="image" src="https://github.com/user-attachments/assets/6b64eef4-53ab-4662-91c6-cefdf590d454" />

<img width="1386" height="659" alt="image" src="https://github.com/user-attachments/assets/f3d77fba-2301-436f-b203-22d37e8d48f4" />

![IMG_20260224_125547](https://github.com/user-attachments/assets/7955ab02-a5c4-4e39-8cab-af50cc757f54)
