### PR TITLE
fix magnet hole crush ribs: correct wave center radius and add param

### DIFF
--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -83,10 +83,12 @@ magnet_easy_release = "auto";//["off","auto","inner","outer"]
 magnet_side_access = "disabled";//[disabled,left:"↰ left",right:"⬑ right"]
 // raise the magnet void inside the part for print-in-magnets
 magnet_captive_height = 0; // .1
-// add a wavy pattern to the magnet hole
-magnet_crush_depth = 0; //0.1
-// add a chamfer to the magent hole
-magnet_chamfer = 0; //0.1
+// add crush ribs to the magnet hole for a tighter press fit (0 = disabled, try 0.15)
+magnet_crush_depth = 0; //0.01
+// number of crush ribs evenly spaced around the magnet hole
+magnet_crush_rib_count = 8; //1
+// add a chamfer to the magnet hole entry to guide the magnet in
+magnet_chamfer = 0; //0.01
 //size of screw, diameter and height. Zack's original used 3 and 6
 screw_size = [3, 6]; // .1
 //size of center magnet, diameter and height.
@@ -342,6 +344,7 @@ gridfinity_cup(
     magnetSideAccess = magnet_side_access,
     magnetCaptiveHeight = magnet_captive_height,
     magnetCrushDepth = magnet_crush_depth,
+    magnetCrushRibCount = magnet_crush_rib_count,
     magnetChamfer = magnet_chamfer,
     centerMagnetSize = center_magnet_size,
     screwSize = enable_screws?screw_size:[0,0],

--- a/modules/module_gridfinity_block.scad
+++ b/modules/module_gridfinity_block.scad
@@ -200,6 +200,7 @@ module grid_block(
           enableSideAccess = cupBase_settings[iCupBase_MagnetSideAccess],
           magnetCaptiveSideAccessSize = [magnetCaptiveSideAccessSize, magnet_size[iCylinderDimension_Diameter], magnet_size[iCylinderDimension_Height]+0.1],
           magnetCrushDepth = cupBase_settings[iCupBase_MagnetCrushDepth],
+          magnetCrushRibCount = cupBase_settings[iCupBase_MagnetCrushRibCount],
           magnetChamfer = cupBase_settings[iCupBase_MagnetChamfer]
         );
     }

--- a/modules/module_gridfinity_cup_base.scad
+++ b/modules/module_gridfinity_cup_base.scad
@@ -48,6 +48,7 @@ iCupBase_AlignGrid=17;
 iCupBase_MagnetSideAccess=18;
 iCupBase_MagnetCrushDepth=19;
 iCupBase_MagnetChamfer=20;
+iCupBase_MagnetCrushRibCount=21;
 
 iCylinderDimension_Diameter=0;
 iCylinderDimension_Height=1;
@@ -107,6 +108,7 @@ function CupBaseSettings(
     magnetCaptiveHeight = 0,
     magnetCrushDepth = 0,
     magnetChamfer = 0,
+    magnetCrushRibCount = 8,
     alignGrid = ["near", "near"],
     magnetSideAccess = false
     ) =
@@ -150,13 +152,14 @@ function CupBaseSettings(
       alignGrid,
       validateMagnetSideAccess(magnetSideAccess),
       magnetCrushDepth,
-      magnetChamfer
+      magnetChamfer,
+      magnetCrushRibCount
       ],
     validatedResult = ValidateCupBaseSettings(result)
   ) validatedResult;
 
 function ValidateCupBaseSettings(settings, num_x, num_y) =
-  assert(is_list(settings) && len(settings) == 21, typeerror_list("CupBase Settings", settings, 19))
+  assert(is_list(settings) && len(settings) == 22, typeerror_list("CupBase Settings", settings, 22))
   assert(is_list(settings[iCupBase_MagnetSize]) && len(settings[iCupBase_MagnetSize])==2, "CupBase Magnet Setting must be a list of length 2")
   assert(is_list(settings[iCupBase_CenterMagnetSize]) && len(settings[iCupBase_CenterMagnetSize])==2, "CenterMagnet Magnet Setting must be a list of length 2")
   assert(is_list(settings[iCupBase_ScrewSize]) && len(settings[iCupBase_ScrewSize])==2, "ScrewSize Magnet Setting must be a list of length 2")
@@ -192,5 +195,6 @@ function ValidateCupBaseSettings(settings, num_x, num_y) =
       settings[iCupBase_AlignGrid],
       settings[iCupBase_MagnetSideAccess],
       settings[iCupBase_MagnetCrushDepth],
-      settings[iCupBase_MagnetChamfer]
+      settings[iCupBase_MagnetChamfer],
+      settings[iCupBase_MagnetCrushRibCount]
       ];

--- a/modules/module_magnet.scad
+++ b/modules/module_magnet.scad
@@ -46,8 +46,9 @@ module MagnetAndScrewRecess(
   easyReleaseRotation = 0,
   magnetRotation = 0,
   magnetCaptiveSideAccessSize = [0,0,0],
-  magnetCrushDepth=0.2,
-  magnetChamfer = 1){
+  magnetCrushDepth = 0,
+  magnetCrushRibCount = 8,
+  magnetChamfer = 0){
   fudgeFactor = 0.01;
     union(){
       SequentialBridgingDoubleHole(
@@ -60,13 +61,13 @@ module MagnetAndScrewRecess(
         magnetCaptiveHeight = magnetCaptiveHeight)
         union(){
           cylinder_wavy(
-            r=magnetDiameter/2,
-            h=$outer_height,
-            amplitude=magnetCrushDepth,
-            frequency = 8);
+            r = magnetDiameter/2 - magnetCrushDepth,
+            h = $outer_height,
+            amplitude = magnetCrushDepth,
+            frequency = magnetCrushRibCount);
           chamferedCylinder(
-            r=magnetDiameter/2-magnetCrushDepth*2,
-            h=$outer_height,
+            r = magnetDiameter/2 - magnetCrushDepth*2,
+            h = $outer_height,
             bottomChamfer = magnetChamfer);
         }
 


### PR DESCRIPTION
The original implementation from #252 passed `r=magnetDiameter/2` to cylinder_wavy, treating the intended hole radius as the wave CENTER. This caused the hole to oscillate ±crushDepth around the magnet diameter: at the wave peaks the hole was larger than the magnet (no grip), making the ribs ineffective.

Instead we should use the passed magnet hole radius as the wave MAXIMUM, so the hole peaks exactly at the magnet diameter and the ribs press inward from there.

Fix: use `r = magnetDiameter/2 - magnetCrushDepth` as the wave center, so the maximum radius equals `magnetDiameter/2`. The chamferedCylinder radius remains at `magnetDiameter/2 - magnetCrushDepth*2` (the wave inner radius), keeping it inside the wavy shape while its entry flare guides the magnet in.

Additional changes:
- Add `magnetCrushRibCount` param (controls wave frequency; default 8) and wire it through `CupBaseSettings` and gridfinity_basic_cup.scad
- Change default crush depth and chamfer from non-zero to 0 (feature off by default; existing users see no change unless they opt in)
- Set Customizer step to 0.01 for crush depth and chamfer so values like 0.15 are directly enterable in the UI