### PR TITLE
Add divider_angle parameter to vertical divider

### DIFF
--- a/gridfinity_vertical_divider.scad
+++ b/gridfinity_vertical_divider.scad
@@ -16,6 +16,8 @@ divider_front_top_inset=20;
 divider_front_top_angle=45;
 divider_back_top_inset=20;
 divider_back_top_angle=45;
+// Tilt angle of each divider in degrees. 0 = upright. Positive leans the top toward +Y (back).
+divider_angle = 0;
 
 /* [Wall Pattern] */
 // Grid wall patter
@@ -249,6 +251,7 @@ module Gridfinity_Divider(
   frontTopAngle=divider_front_top_angle,
   backTopInset=divider_back_top_inset,
   backTopAngle=divider_back_top_angle,
+  dividerAngle=divider_angle,
   wallpatternEnabled=wallpattern_enabled,
   pattern_settings = PatternSettings(
     patternEnabled = wallpattern_enabled,
@@ -284,6 +287,9 @@ module Gridfinity_Divider(
     canvis = [dividerHeight, num_x*env_pitch().x-env_clearance().x];
     ypos = (num_y*env_pitch().y-env_corner_radius()*2-dividerWidth)/(divider_count-1)*i;
     translate([env_clearance().x/2,env_corner_radius()+dividerWidth+ypos,floorHeight])
+    // Clip anything that would extend below the cup floor when tilted
+    difference(){
+    rotate([dividerAngle,0,0])
     PatternedDivider(
       height = canvis.x,
       length = canvis.y,
@@ -335,5 +341,9 @@ module Gridfinity_Divider(
           rotateGrid = pattern_settings[iPatternRotate],
           patternFs = pattern_settings[iPatternFs]);
         }
+      // Subtract the half-space below the cup floor (local z < 0)
+      translate([-fudgeFactor, -num_y*env_pitch().y, -num_y*env_pitch().y])
+        cube([num_x*env_pitch().x+fudgeFactor*2, num_y*env_pitch().y*2, num_y*env_pitch().y]);
+    }
     }
 }


### PR DESCRIPTION
## Summary

Adds an optional `divider_angle` parameter to `gridfinity_vertical_divider.scad` that tilts each divider by a given angle (in degrees). `0` keeps the current upright behaviour, so it's fully backward-compatible — existing models are unchanged.

Positive values lean the top of each divider toward +Y (the back). This is handy for things like angled card/tool holders where you want items to rest at a slight recline.

## Implementation

- New `divider_angle` customizer parameter (default `0`), documented in the `[Divider]` section.
- Threaded through `Gridfinity_Divider()` as a `dividerAngle` argument.
- The divider is wrapped in a `rotate([dividerAngle,0,0])`, and a `difference()` subtracts the half-space below the cup floor (local `z < 0`) so a tilted divider is cleanly clipped flush to the floor instead of poking through it.

## Testing

Rendered the vertical divider at `divider_angle = 0` (identical to current output) and at several positive angles, confirming the dividers tilt as expected and stay clipped at the floor.

## Notes

I checked the open issues and existing PRs — I couldn't find an existing request or PR for tilted/angled dividers, so this isn't linked to anything. Happy to adjust naming or the default behaviour to fit the project's conventions.